### PR TITLE
Findability & proof: per-page metadata, sitemap, honest pricing in llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist
 
 # node
 node_modules
+
+# agent working notes — keep local, never commit to a branch
+docs/superpowers/
+.superpowers/

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -3,24 +3,79 @@
 
   <head>
     <meta charset="utf-8">
-    <title>{{ title }}</title>
-    {% if description %}
-      <meta name="description" content="{{description}}">
-    {% endif %}
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 
-    <meta property="og:title" content="{{ title }}">
-    {% if description %}
-      <meta property="og:description" content="{{description}}">
+    {% comment %} Title suffix varies by area so 15 docs pages don't collide. {% endcomment %}
+    {% if area == 'docs' %}
+      {% assign title_suffix = 'Archival Docs' %}
+    {% elsif area == 'cli' %}
+      {% assign title_suffix = 'Archival CLI' %}
+    {% else %}
+      {% assign title_suffix = 'Archival' %}
     {% endif %}
+
+    {% comment %} Bare truthy-guard before comparing or filtering: this Liquid
+       engine errors on Unknown variable if a layout arg that was never passed
+       at all (e.g. pages/cli.liquid omits description and path) is compared or
+       filtered directly. A bare truthy check on an unset var is safe and falsy,
+       so it lets us fall through to the blank-safe defaults without crashing. {% endcomment %}
+    {% if title %}
+      {% assign title_str = title %}
+    {% else %}
+      {% assign title_str = blank %}
+    {% endif %}
+    {% if title_str == blank %}
+      {% assign page_title = home.title %}
+    {% else %}
+      {% assign page_title = title_str | append: ' | ' | append: title_suffix %}
+    {% endif %}
+
+    {% if description %}
+      {% assign meta_description = description | strip_html | strip | truncate: 155 %}
+    {% else %}
+      {% assign meta_description = "" %}
+    {% endif %}
+
+    {% if path %}
+      {% assign path_str = path %}
+    {% else %}
+      {% assign path_str = blank %}
+    {% endif %}
+    {% if path_str == blank %}
+      {% assign canonical_url = site_url | append: '/' %}
+    {% else %}
+      {% assign canonical_url = site_url | append: '/' | append: path_str | append: '.html' %}
+    {% endif %}
+
+    <title>{{ page_title }}</title>
+    {% unless meta_description == blank %}
+      <meta name="description" content="{{ meta_description | escape }}">
+    {% endunless %}
+    {% if noindex %}
+      <meta name="robots" content="noindex">
+    {% endif %}
+    <link rel="canonical" href="{{ canonical_url }}" />
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <meta property="og:title" content="{{ page_title | escape }}">
+    {% unless meta_description == blank %}
+      <meta property="og:description" content="{{ meta_description | escape }}">
+    {% endunless %}
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://archival.dev">
-    <meta property="og:image" content="https://archival.dev/img/og-image.png" />
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ site_url }}/img/og-image.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1024" />
     <meta property="og:image:height" content="1024" />
     <meta property="og:image:alt" content="archival.dev" />
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ page_title | escape }}">
+    {% unless meta_description == blank %}
+      <meta name="twitter:description" content="{{ meta_description | escape }}">
+    {% endunless %}
+    <meta name="twitter:image" content="{{ site_url }}/img/og-image.png">
 
     <link rel="manifest" href="/site.webmanifest" />
 
@@ -61,17 +116,31 @@
       {{ page_content }}
     </main>
 
-    <!-- syntax highlighting -->
-    <link rel="stylesheet" href="/style/hljs-dracula.css" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    {% if area == 'docs' or area == 'cli' %}
+      <!-- syntax highlighting -->
+      <link rel="stylesheet" href="/style/hljs-dracula.css" />
+      <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+        integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp"
+        crossorigin="anonymous"></script>
 
-    <!-- documentation languages -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/javascript.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/typescript.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/toml.min.js"></script>
-    <script>
-          hljs.highlightAll();
-    </script>
+      <!-- documentation languages -->
+      <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/javascript.min.js"
+        integrity="sha384-44q2s9jxk8W5N9gAB0yn7UYLi9E2oVw8eHyaTZLkDS3WuZM/AttkAiVj6JoZuGS4"
+        crossorigin="anonymous"></script>
+      <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/typescript.min.js"
+        integrity="sha384-ORwtVEfrCZ0gzGacgmfv1wOtxcPIaVfHKwq8dKQjObRwx3qpKjsSg1ldTu1PEgXd"
+        crossorigin="anonymous"></script>
+      <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/ini.min.js"
+        integrity="sha384-QrHbXsWtJOiJjnLPKgutUfoIrj34yz0+JKPw4CFIDImvaTDQ/wxYyEz/zB3639vM"
+        crossorigin="anonymous"></script>
+      <script>
+        hljs.highlightAll();
+      </script>
+    {% endif %}
     <script
       defer
       src="/umami.js"
@@ -83,7 +152,7 @@
       <footer class="footer">
         <img src="/img/archival-mark.svg" class="footer-mark" />
         <p class="copyright">&copy;       
-        2025 Fuck Billionaires, LLC.<br>All rights reserved.</p>
+        2026 Fuck Billionaires, LLC.<br>All rights reserved.</p>
         <p class="footer-legal">
           <a href="/privacy.html" data-umami-event="footer-privacy">Privacy</a>
           |

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -46,7 +46,7 @@
       {% assign canonical_url = site_url | append: '/' | append: path_str | append: '.html' %}
     {% endif %}
 
-    <title>{{ page_title }}</title>
+    <title>{{ page_title | escape }}</title>
     {% unless meta_description == blank %}
       <meta name="description" content="{{ meta_description | escape }}">
     {% endunless %}

--- a/objects.toml
+++ b/objects.toml
@@ -56,6 +56,7 @@ content = "markdown"
 
 [cli]
 command = "string"
+description = "string"
 content = "markdown"
 template = "cli"
 [cli.options]

--- a/objects.toml
+++ b/objects.toml
@@ -82,3 +82,20 @@ description = "string"
 key = "string"
 title = "string"
 content = "markdown"
+
+[showcase]
+title = "string"
+tagline = "string"
+
+[showcase.sites]
+name = "string"
+url = "string"
+screenshot = "image"
+description = "string"
+built_by = "string"
+
+[showcase.quotes]
+quote = "markdown"
+author = "string"
+role = "string"
+site_url = "string"

--- a/objects/cli/build.toml
+++ b/objects/cli/build.toml
@@ -1,5 +1,6 @@
 order = 0
 command = "archival build"
+description = "Build your archival site into static files, ready to deploy to any host."
 content = """
 Build an archival site - this will generate a static site inside a directory (dist unless you have overridden it in manifest.toml).
 """

--- a/objects/cli/compat.toml
+++ b/objects/cli/compat.toml
@@ -1,5 +1,6 @@
 order = 2
 command = "archival compat"
+description = "Check this version of archival's compatibility against a version string, exiting non-zero if incompatible."
 content = """
 Checks the compatibility of this version of archival against a version string. This will return a non-zero exit code if the specified version is incompatible - generally this is used during CI or automated builds.
 """

--- a/objects/cli/format.toml
+++ b/objects/cli/format.toml
@@ -1,5 +1,6 @@
 order = 9
 command = "archival format"
+description = "Rewrite an archival site's toml files into archival's canonical formatting."
 content = """
 Rewrites all of the toml files in an archival site — the `manifest.toml` and every object file — into archival’s canonical formatting. This is useful for keeping a site’s files tidy and consistent, especially across a team or as part of a CI check.
 

--- a/objects/cli/import.toml
+++ b/objects/cli/import.toml
@@ -1,5 +1,6 @@
 order = 3
 command = "archival import"
+description = "Import external structured data into archival object files, for automated workflows or initial site data population."
 content = """
 This command handles importing external structured data into archival object files, and typically is used during automated workflows or initial site data population.
 """

--- a/objects/cli/login.toml
+++ b/objects/cli/login.toml
@@ -1,5 +1,6 @@
 order = 6
 command = "archival login"
+description = "Log in to the archival editor and store credentials locally in ~/.archivalrc."
 content = """
 Logs in to the archival editor and store credentials locally in `~/.archivalrc`.
 

--- a/objects/cli/manifest.toml
+++ b/objects/cli/manifest.toml
@@ -1,5 +1,6 @@
 order = 4
 command = "archival manifest"
+description = "Print the value of a manifest field, useful in a build script or CI environment."
 content = """
 Print the value from a manifest field - typically this is useful in the context of a build script or CI environment.
 """

--- a/objects/cli/objects.toml
+++ b/objects/cli/objects.toml
@@ -1,5 +1,6 @@
 order = 7
 command = "archival objects"
+description = "List the objects defined in a site, in a debug-friendly format, mainly useful when troubleshooting a build issue."
 content = """
 Lists the objects defined in this site, in a debug-friendly format. Mainly useful when troubleshooting a build issue.
 

--- a/objects/cli/prebuild.toml
+++ b/objects/cli/prebuild.toml
@@ -1,5 +1,6 @@
 order = 5
 command = "archival prebuild"
+description = "Run the commands listed in the manifest's prebuild field, in sequence, exiting non-zero on failure."
 content = """
 Runs the commands listed in the manifest prebuild fields, in sequence, in subshells. If any command fails, this will print the failure and exit non-zero.
 """

--- a/objects/cli/run.toml
+++ b/objects/cli/run.toml
@@ -1,5 +1,6 @@
 order = 1
 command = "archival run"
+description = "Run a local static server that watches your archival site and automatically rebuilds it whenever files change."
 content = """
 This command runs a local static server and watches your archival site for changes. The site will be automatically rebuilt whenever files change.
 

--- a/objects/cli/schemas.toml
+++ b/objects/cli/schemas.toml
@@ -1,5 +1,6 @@
 order = 10
 command = "archival schemas"
+description = "Generate JSON Schema files from your site's object definitions, for editor autocomplete, CI validation, and structured LLM outputs."
 content = """
 Generates [JSON Schema](https://json-schema.org/) files from your site’s object definitions. These schemas describe the exact shape of each object type, which is useful for editor autocomplete and inline validation while you hand-edit object toml files, for validating data in CI, and for sending to LLMs that support structured outputs.
 

--- a/objects/cli/upload.toml
+++ b/objects/cli/upload.toml
@@ -1,5 +1,6 @@
 order = 8
 command = "archival upload"
+description = "Upload a file to archival's CDN and store the resulting metadata in a local object field."
 content = """
 Uploads a file to archival’s CDN and sets a field in a local object with the resulting metadata. When uploading files via the command line, this allows you to do the same thing the editor does, which is to upload and store the uploaded sha in a local file field.
 """

--- a/objects/docs/getting-started.toml
+++ b/objects/docs/getting-started.toml
@@ -1,5 +1,8 @@
 order = 0
 title = "Getting Started"
+description = """
+Set up a new archival site through the hosted editor at editor.archival.dev, or install the archival CLI locally to clone, build, and run your site from a git repo.
+"""
 
 [[sections]]
 title = "Using editor.archival.dev/new"

--- a/objects/home.toml
+++ b/objects/home.toml
@@ -10,11 +10,13 @@ videos_title = "Show Me How It Works"
 contact_title = "Connect With Us"
 pricing_title = "Pricing"
 pricing_content = """
-Archival is run by a tiny team with a goal of staying small. You can use archival for free forever, and you can ship archival sites to platforms like Vercel, Netlify, or host archival websites on your own static servers.
+Archival is run by a tiny team with a goal of staying small.
 
-Our goal is to be as easy as a social media profile to build and maintain, while being far less expensive than more complicated web platforms. Our pricing is ridiculously simple - <span class="emphasized">for $14 a month, you get unlimited traffic to your archival-hosted site, the ability to upload large streaming files and add custom domains.
+The Archival editor — hosting, custom domains, DNS, and large file uploads — is $14 a month. That is the whole price: no tiers, no hidden charges. Hosted sites include 100GB of bandwidth and 10GB of storage per month.
 
-If you’re interested in hiring the archival team to build something custom for you, host a large number of sites on archival, or otherwise find our pricing model imperfect for your use case, reach out to [pricing@archival.dev](mailto:pricing@archival.dev) and we’ll get you what you need!
+Archival itself is open source. The `archival` CLI is free to use and always will be, and you can build archival sites and host them yourself, or deploy them to platforms like Vercel, Netlify, or any static host.
+
+If you're interested in hiring the archival team to build something custom for you, host a large number of sites on archival, or otherwise find our pricing model imperfect for your use case, reach out to [pricing@archival.dev](mailto:pricing@archival.dev) and we'll get you what you need!
 """
 discord_url = "https://discord.gg/Q9Cj6bWTbW"
 

--- a/objects/showcase.toml
+++ b/objects/showcase.toml
@@ -1,0 +1,50 @@
+title = "Built with Archival"
+tagline = "Real sites, running on Archival today."
+
+[[sites]]
+name = "Example Site One"
+url = "https://example.com"
+description = "PLACEHOLDER — replace with a real site built on Archival."
+built_by = "PLACEHOLDER"
+
+[sites.screenshot]
+sha = ""
+display_type = "image"
+filename = ""
+mime = "image/*"
+
+[[sites]]
+name = "Example Site Two"
+url = "https://example.com"
+description = "PLACEHOLDER — replace with a real site built on Archival."
+built_by = "PLACEHOLDER"
+
+[sites.screenshot]
+sha = ""
+display_type = "image"
+filename = ""
+mime = "image/*"
+
+[[sites]]
+name = "Example Site Three"
+url = "https://example.com"
+description = "PLACEHOLDER — replace with a real site built on Archival."
+built_by = "PLACEHOLDER"
+
+[sites.screenshot]
+sha = ""
+display_type = "image"
+filename = ""
+mime = "image/*"
+
+[[quotes]]
+quote = "[Quote pending approval — do not publish]"
+author = "PLACEHOLDER"
+role = "PLACEHOLDER"
+site_url = ""
+
+[[quotes]]
+quote = "[Quote pending approval — do not publish]"
+author = "PLACEHOLDER"
+role = "PLACEHOLDER"
+site_url = ""

--- a/pages/_legal.liquid
+++ b/pages/_legal.liquid
@@ -1,5 +1,7 @@
 {% layout "theme" title: title
-  , area: "legal" %}
+  , area: "legal"
+  , description: content
+  , path: path %}
 
 <div class="legal">
   <div class="nav-top container">

--- a/pages/chat.liquid
+++ b/pages/chat.liquid
@@ -1,5 +1,8 @@
-{% layout 'theme' title: "archival"
-  , area: "home" %}
+{% layout 'theme' title: "Chat"
+  , area: "home"
+  , description: "Join the Archival community on Discord."
+  , path: "chat"
+  , noindex: true %}
 
 
 <div id="header" class="z-30 w-full flex flex-col justify-center items-center gap-6 md:pt-20 relative">

--- a/pages/cli.liquid
+++ b/pages/cli.liquid
@@ -1,5 +1,7 @@
-{% layout 'theme' title: "Archival | CLI"
+{% layout 'theme' title: cli.command
   , area: "cli"
+  , description: cli.description
+  , path: cli.path
   , nofooter: true %}
 
 <div class="docs-container mb-20 md:mb-0 md:mt-20 flex flex-1 gap-4 min-h-full w-full md:max-w-[1200px] pt-32 pb-32">

--- a/pages/docs.liquid
+++ b/pages/docs.liquid
@@ -1,5 +1,7 @@
-{% layout 'theme' title: "Archival | Docs"
+{% layout 'theme' title: docs.title
   , area: "docs"
+  , description: docs.description
+  , path: docs.path
   , nofooter: true %}
 
 <div class="docs-container md:mb-0 md:mt-20 flex flex-1 gap-4 min-h-full w-full md:max-w-[1200px] pt-32 pb-32">

--- a/pages/eula.liquid
+++ b/pages/eula.liquid
@@ -1,2 +1,3 @@
 {% include "legal" title: "End User License Agreement"
-  , content: eula.content %}
+  , content: eula.content
+  , path: "eula" %}

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -1,4 +1,4 @@
-{% layout 'theme' title: home.title, area: "home" %}
+{% layout 'theme' area: "home", description: home.description, path: "" %}
 {% assign home = objects.home %}
 
 <div id="header" class="w-full flex flex-col justify-center items-center gap-6 pt-60 relative">

--- a/pages/manifesto.liquid
+++ b/pages/manifesto.liquid
@@ -1,5 +1,7 @@
-{% layout 'theme' title: "Archival | Manifesto"
-  , area: "manifesto" %}
+{% layout 'theme' title: "Manifesto"
+  , area: "manifesto"
+  , description: manifesto.content
+  , path: "manifesto" %}
 {% assign home = objects.home %}
 
 <div class="manifesto">

--- a/pages/pricing.liquid
+++ b/pages/pricing.liquid
@@ -1,5 +1,7 @@
-{% layout 'theme' title: "Archival | Pricing"
-  , area: "pricing" %}
+{% layout 'theme' title: "Pricing"
+  , area: "pricing"
+  , description: pricing.tagline
+  , path: "pricing" %}
 
 {% assign pricing = objects.pricing %}
 

--- a/pages/privacy.liquid
+++ b/pages/privacy.liquid
@@ -1,2 +1,3 @@
 {% include "legal" title: "Privacy Policy"
-  , content: privacy_policy.content %}
+  , content: privacy_policy.content
+  , path: "privacy" %}

--- a/pages/product.liquid
+++ b/pages/product.liquid
@@ -1,5 +1,6 @@
 {% layout 'theme' title: objects.product.title
   , description: objects.product.description
+  , path: "product"
   , area: "product" %}
 {% assign product = objects.product %}
 

--- a/pages/showcase.liquid
+++ b/pages/showcase.liquid
@@ -1,0 +1,43 @@
+{% layout 'theme' title: showcase.title
+  , area: "showcase"
+  , description: showcase.tagline
+  , path: "showcase"
+  , noindex: true %}
+
+<div class="w-full flex flex-col justify-center items-center gap-6 pt-60 relative">
+  <h1 class="hero-message" data-tilt-hero>
+    <span class="hero-line-1">built with</span>
+    <span class="hero-line-2">archival</span>
+  </h1>
+  <p class="build-description">{{ showcase.tagline }}</p>
+</div>
+
+<div class="benefit-grid md:max-w-[1200px] md:mt-40 md:mb-40 mt-20 mb-20">
+  {% for site in showcase.sites %}
+    <div class="benefit" data-tilt>
+      <a href="{{ site.url }}" target="_blank" rel="noopener" data-umami-event="showcase-site" data-umami-event-site="{{ site.name }}">
+        {% if site.screenshot.url %}
+          <img src="{{ site.screenshot.url }}" alt="{{ site.name }}" class="w-full rounded-lg mb-4" />
+        {% endif %}
+        <h2 class="section-title">{{ site.name }}</h2>
+        <div class="section-content">
+          <p>{{ site.description }}</p>
+          {% unless site.built_by == blank %}
+            <p class="text-sm opacity-70">Built by {{ site.built_by }}</p>
+          {% endunless %}
+        </div>
+      </a>
+    </div>
+  {% endfor %}
+</div>
+
+<div class="benefit-grid md:max-w-[1200px] mb-40">
+  {% for quote in showcase.quotes %}
+    <div class="benefit" data-tilt>
+      <div class="section-content">
+        {{ quote.quote }}
+        <p class="text-sm opacity-70">— {{ quote.author }}, {{ quote.role }}</p>
+      </div>
+    </div>
+  {% endfor %}
+</div>

--- a/pages/showcase.liquid
+++ b/pages/showcase.liquid
@@ -16,9 +16,9 @@
   {% for site in showcase.sites %}
     <div class="benefit" data-tilt>
       <a href="{{ site.url }}" target="_blank" rel="noopener" data-umami-event="showcase-site" data-umami-event-site="{{ site.name }}">
-        {% if site.screenshot.url %}
-          <img src="{{ site.screenshot.url }}" alt="{{ site.name }}" class="w-full rounded-lg mb-4" />
-        {% endif %}
+        {% unless site.screenshot.url == blank %}
+          <img src="{{ site.screenshot.url }}" alt="Screenshot of {{ site.name }}" class="w-full rounded-lg mb-4" />
+        {% endunless %}
         <h2 class="section-title">{{ site.name }}</h2>
         <div class="section-content">
           <p>{{ site.description }}</p>

--- a/pages/sitemap.xml.liquid
+++ b/pages/sitemap.xml.liquid
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>{{ site_url }}/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>{{ site_url }}/pricing.html</loc>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>{{ site_url }}/manifesto.html</loc>
+    <priority>0.8</priority>
+  </url>
+  {% for doc in objects.docs %}
+  <url>
+    <loc>{{ site_url }}/{{ doc.path }}.html</loc>
+    <priority>0.6</priority>
+  </url>
+  {% endfor %}
+  {% for command in objects.cli %}
+  <url>
+    <loc>{{ site_url }}/{{ command.path }}.html</loc>
+    <priority>0.5</priority>
+  </url>
+  {% endfor %}
+  <url>
+    <loc>{{ site_url }}/privacy.html</loc>
+    <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>{{ site_url }}/terms-of-service.html</loc>
+    <priority>0.2</priority>
+  </url>
+  <url>
+    <loc>{{ site_url }}/eula.html</loc>
+    <priority>0.2</priority>
+  </url>
+</urlset>

--- a/pages/sitemap.xml.liquid
+++ b/pages/sitemap.xml.liquid
@@ -5,6 +5,10 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>{{ site_url }}/product.html</loc>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>{{ site_url }}/pricing.html</loc>
     <priority>0.9</priority>
   </url>

--- a/pages/terms-of-service.liquid
+++ b/pages/terms-of-service.liquid
@@ -1,2 +1,3 @@
 {% include "legal" title: "Terms of Service"
-  , content: terms_of_service.content %}
+  , content: terms_of_service.content
+  , path: "terms-of-service" %}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://archival.dev/sitemap.xml

--- a/scripts/check-meta.sh
+++ b/scripts/check-meta.sh
@@ -6,6 +6,11 @@ cd "$(dirname "$0")/.." || exit 1
 fail=0
 pages=$(find dist -name '*.html' ! -path 'dist/api/*')
 
+if [ -z "$pages" ]; then
+  echo "FAIL: no HTML found in dist/ — run 'npm run build' first"
+  exit 1
+fi
+
 for f in $pages; do
   grep -q '<meta name="description"' "$f" || { echo "MISSING description: $f"; fail=1; }
   grep -q '<link rel="canonical"' "$f"    || { echo "MISSING canonical:   $f"; fail=1; }

--- a/scripts/check-meta.sh
+++ b/scripts/check-meta.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Verifies every marketing/docs page has unique title, a meta description, and a canonical URL.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+fail=0
+pages=$(find dist -name '*.html' ! -path 'dist/api/*')
+
+for f in $pages; do
+  grep -q '<meta name="description"' "$f" || { echo "MISSING description: $f"; fail=1; }
+  grep -q '<link rel="canonical"' "$f"    || { echo "MISSING canonical:   $f"; fail=1; }
+done
+
+dupes=$(grep -ho '<title>[^<]*</title>' $pages | sort | uniq -d)
+if [ -n "$dupes" ]; then
+  echo "DUPLICATE titles:"; echo "$dupes"; fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then echo "PASS: all pages have unique titles, descriptions, and canonicals"; fi
+exit "$fail"


### PR DESCRIPTION
Fixes the two things a fresh audit of the site surfaced: **search engines and AI assistants can't see us**, and **nothing on the site gives a prospective customer a reason to trust us.**

## The headline bug

Every page shipped with **zero meta description**. `theme.liquid` guarded its description tag on `{% if description %}`, but no page ever passed one — the copy existed in `home.toml` and was simply never wired up. All 15 docs pages also shared one identical `<title>` ("Archival | Docs"), and all 11 CLI pages shared another.

`theme.liquid` now *composes* metadata from parts each page passes in (`title`, `description`, `path`), so ~30 pages get unique metadata without editing ~30 files.

## What's in here

- **Per-page metadata** — unique titles, meta descriptions, canonical URLs, correct `og:url` (was hardcoded to the homepage on every page), and Twitter Cards. The 15 docs descriptions already existed in the TOML and had just never been rendered.
- **`sitemap.xml` + `robots.txt`** — neither existed; crawlers were finding docs by luck.
- **Honest pricing in `/llms.txt`** — `home.pricing_content` renders *only* into `/llms.txt`, the file AI assistants read. It promised "free forever" and "unlimited traffic", both contradicted by the pricing page. Now matches the human story: $14/mo, 100GB, 10GB, with the free path correctly scoped to the open-source CLI.
- **TOML syntax highlighting, fixed** — `languages/toml.min.js` **404s on cdnjs and never existed**. On a product whose entire content model is TOML, the docs have never highlighted a single TOML block. TOML lives in the `ini` pack (`aliases:["toml"]`). Verified working in a real browser.
- **Pinch-zoom restored** — the viewport meta set `user-scalable=0` (WCAG 1.4.4 failure).
- **highlight.js only where there's code** — was 4 blocking CDN requests on the homepage and pricing page for zero code blocks. Also added SRI hashes.
- **`scripts/check-meta.sh`** — a committed check that every page has a unique title, a description, and a canonical. Run it in CI.

## Showcase page — deliberately NOT published

`/showcase.html` is scaffolded but holds **obvious placeholders** ("Example Site One", "[Quote pending approval]"). It is `noindex`, absent from the sitemap, and linked from nowhere.

**Do not publish it until real sites and permission-cleared quotes are in.** Launch steps are written down in the plan. No fabricated social proof anywhere in this branch.

## Merge conflicts with `feat/product-tour-page`

Deliberately kept minimal: one layout-arg line each in `index.liquid` and `pricing.liquid`, and two additive blocks in `objects.toml`.

## Still open (not addressed here)

- `objects/pricing.toml` still says "Unlimited page views and visitors" while `llms.txt` now says 100GB/mo — same class of contradiction this PR set out to kill, but that file belongs to the tour branch.
- The pricing page asserts a "99.9% uptime guarantee", "daily backups", and a "professional design team". Worth confirming those are all true before we amplify them.
- The developer/buyer front-door split — wants to be designed against the new homepage once the tour branch merges.