### PR TITLE
Replace the onboarding iframe with the template gallery

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -14,6 +14,14 @@ const API_URL = dev
   : staging
     ? "https://api.archival-staging.dev"
     : "https://api.archival.dev";
+// Where the template gallery lives, and where templates.json and the template
+// thumbnails are served from. It answers with access-control-allow-origin: *,
+// so the mosaic can read the catalog at runtime.
+const EDITOR_URL = dev
+  ? "http://localhost:8788"
+  : staging
+    ? "https://editor.archival-staging.dev"
+    : "https://editor.archival.dev";
 const TURNSTILE_SITE_KEY = dev
   ? "1x00000000000000000000AA"
   : staging
@@ -31,7 +39,7 @@ const ctx = await esbuild.context({
   plugins: [metaUrlPlugin()],
   define: {
     DEV: dev ? "true" : "false",
-    LANDING_IFRAME_URL: `"${dev ? "http://localhost:8788/landing-iframe.html" : "https://editor.archival.dev/landing-iframe.html"}"`,
+    EDITOR_URL: `"${EDITOR_URL}"`,
     API_URL: `"${API_URL}"`,
     TURNSTILE_SITE_KEY: `"${TURNSTILE_SITE_KEY}"`,
   },

--- a/define.d.ts
+++ b/define.d.ts
@@ -2,6 +2,7 @@
 // they will be baked into the app.
 
 declare const DEV: boolean;
-declare const LANDING_IFRAME_URL: string;
+/** Origin of the editor: the template gallery, templates.json and thumbnails. */
+declare const EDITOR_URL: string;
 declare const API_URL: string;
 declare const TURNSTILE_SITE_KEY: string;

--- a/objects/product.toml
+++ b/objects/product.toml
@@ -6,7 +6,7 @@ description = "See the Archival editor. Describe a site and it's built, edit con
 key = "prompt"
 title = "Get started in minutes"
 content = """
-Start with a description, then attach any photos, video, or audio you already have. Archival chooses one of our human-built templates to get you started, and populates content based on your prompt.
+Pick one of our human-built templates and see it running before you choose. Describe your site and attach any photos, video, or audio you already have, and we'll fill it in — or skip that and edit the demo content yourself.
 """
 
 [[sections]]

--- a/objects/product.toml
+++ b/objects/product.toml
@@ -6,7 +6,7 @@ description = "See the Archival editor. Describe a site and it's built, edit con
 key = "prompt"
 title = "Get started in minutes"
 content = """
-Pick one of our human-built templates and see it running before you choose. Describe your site and attach any photos, video, or audio you already have, and we'll fill it in — or skip that and edit the demo content yourself.
+Pick one of our templates (built by humans!) and see it running right away, or describe your site and/or attach some files and we'll fill it in. Then customize it to your heart's content before you publish.
 """
 
 [[sections]]

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -308,61 +308,54 @@
             </li>
           </ol>
         {% elsif section.key == "prompt" %}
+          {% comment %}
+            The flow this draws: choose a template, optionally say something
+            about your site, generate. Built from the same .pf-* primitives the
+            other frames use rather than a vocabulary of its own: the optional
+            box IS .pf-prompt-card, unchanged. That reuse is true to the
+            product - describing your site moved from being the way in to being
+            one thing you can do once you have picked, so it should read as the
+            same control, demoted.
+
+            Every element in here carries a number. A detail view of the picked
+            template was drawn here once and was the only thing that did not,
+            which is what gave it away as decoration rather than a step.
+          {% endcomment %}
           <div class="product-frame product-frame--prompt">
             <div class="product-frame-glow" aria-hidden="true"></div>
 
-            {% comment %} Glowing AI prompt card {% endcomment %}
-            <div class="pf-prompt-card pf-glass">
-              <div class="pf-prompt-textarea" data-callout-target="1">
-                Describe what type of site you'd like to create&hellip;
-              </div>
-              <div class="pf-prompt-row">
-                <div class="pf-attach-row" data-callout-target="2">
-                  <span class="pf-chip"> <i class="pf-chip-icon" aria-hidden="true"></i>Photos</span>
-                  <span class="pf-chip"> <i class="pf-chip-icon" aria-hidden="true"></i>Video</span>
-                  <span class="pf-chip"> <i class="pf-chip-icon" aria-hidden="true"></i>Audio</span>
-                </div>
-                <button class="pf-cta pf-generate-btn" type="button">Generate</button>
+            {% comment %} The gallery, as a strip. One is picked. {% endcomment %}
+            <div class="pf-choose">
+              <p class="pf-frame-title">Select a template</p>
+              <div class="pf-tile-strip" data-callout-target="1">
+                <span class="pf-tile"><i class="pf-tile-header"></i><i class="pf-tile-body"></i></span>
+                <span class="pf-tile"><i class="pf-tile-header"></i><i class="pf-tile-body"></i></span>
+                <span class="pf-tile pf-tile--active">
+                  <i class="pf-tile-header"></i><i class="pf-tile-body"></i>
+                </span>
+                <span class="pf-tile"><i class="pf-tile-header"></i><i class="pf-tile-body"></i></span>
+                <span class="pf-tile"><i class="pf-tile-header"></i><i class="pf-tile-body"></i></span>
+                <span class="pf-tile"><i class="pf-tile-header"></i><i class="pf-tile-body"></i></span>
               </div>
             </div>
 
-            {% comment %} 3-up generated template chooser {% endcomment %}
-            <div class="pf-chooser" data-callout-target="3">
-              <button
-                class="pf-paddle pf-paddle-prev"
-                type="button"
-                aria-label="Previous site"
-              >
-                &#8249;
-              </button>
-
-              <div class="pf-site-card">
-                <div class="pf-site-header"></div>
-                <div class="pf-site-block pf-site-block--wide"></div>
-                <div class="pf-site-block"></div>
+            <div class="pf-prompt-card pf-glass" data-callout-target="2">
+              <span class="pf-optional-label">Optional</span>
+              <div class="pf-prompt-textarea">Tell us about your site&hellip;</div>
+              <div class="pf-attach-row">
+                <span class="pf-chip"> <i class="pf-chip-icon" aria-hidden="true"></i>Photos</span>
+                <span class="pf-chip"> <i class="pf-chip-icon" aria-hidden="true"></i>Video</span>
+                <span class="pf-chip"> <i class="pf-chip-icon" aria-hidden="true"></i>Audio</span>
               </div>
-
-              <div class="pf-site-card pf-site-card--active">
-                <div class="pf-site-header"></div>
-                <div class="pf-site-block pf-site-block--wide"></div>
-                <div class="pf-site-block"></div>
-                <button class="pf-cta pf-golive-btn" type="button">Go Live</button>
-              </div>
-
-              <div class="pf-site-card">
-                <div class="pf-site-header"></div>
-                <div class="pf-site-block pf-site-block--wide"></div>
-                <div class="pf-site-block"></div>
-              </div>
-
-              <button
-                class="pf-paddle pf-paddle-next"
-                type="button"
-                aria-label="Next site"
-              >
-                &#8250;
-              </button>
             </div>
+
+            <button
+              class="pf-cta pf-generate-btn"
+              type="button"
+              data-callout-target="3"
+            >
+              Generate
+            </button>
 
             <button
               type="button"
@@ -394,32 +387,17 @@
           </div>
 
           <ol class="callout-legend">
-            <li
-              class="callout-item"
-              data-callout="1"
-              id="c2-1"
-              style="--i:1;"
-            >
+            <li class="callout-item" data-callout="1" id="c2-1" style="--i:1;">
               <b>1</b>
-              Describe your site in plain language.
+              Pick a template and see it running.
             </li>
-            <li
-              class="callout-item"
-              data-callout="2"
-              id="c2-2"
-              style="--i:2;"
-            >
+            <li class="callout-item" data-callout="2" id="c2-2" style="--i:2;">
               <b>2</b>
-              Attach photos, video, or audio you already have.
+              Describe your site, and attach what you already have.
             </li>
-            <li
-              class="callout-item"
-              data-callout="3"
-              id="c2-3"
-              style="--i:3;"
-            >
+            <li class="callout-item" data-callout="3" id="c2-3" style="--i:3;">
               <b>3</b>
-              Pick from several complete, real sites and go live.
+              Generate, and it is yours to edit.
             </li>
           </ol>
         {% elsif section.key == "media" %}

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -82,30 +82,27 @@
 {% comment %} Build Section {% endcomment %}
 
 <div class="build-section">
+  {% comment %}
+    One line between the hero and the grid, not three. It used to be this
+    heading, a two-line description and a "Featured templates" label stacked on
+    each other, which is a lot of talking in front of twelve screenshots that
+    say it themselves. "yours" is picked up from "websites for everyone"
+    directly above, so the two read as one thought rather than two headings.
+  {% endcomment %}
   <h2 class="build-heading">Build yours right now.</h2>
-  <p class="build-description">
-    Pick a template and make it yours.<br class="build-description-break" />
-    You can change all of it later.
-  </p>
 
   {% comment %}
     The mosaic is filled in by setupTemplateMosaic() in src/index.ts from the
     editor's templates.json. Everything that matters is already here: the
     heading, the line above, and the link below all work with no JS and no
     network, so a failed fetch leaves a section that still reads and still has
-    somewhere to go, rather than a hole. The label is inside the hidden
-    wrapper rather than beside it, so it never introduces a grid that is not
-    there.
+    somewhere to go, rather than a hole.
 
     It is a fixed window onto the catalog, not the whole of it - twelve tiles
-    whatever the catalog grows to, with the remainder named in the link. A
-    grid of forty thumbnails does not read as "forty templates" to anyone; a
-    tidy dozen and a number does.
+    whatever the catalog grows to. Which twelve is authored in the editor's
+    objects/templates/*.toml; see MOSAIC_TILES in src/index.ts.
   {% endcomment %}
-  <div id="featured-templates" class="featured-templates" hidden>
-    <h3 class="featured-heading">Featured templates</h3>
-    <div id="template-mosaic" class="template-mosaic"></div>
-  </div>
+  <div id="template-mosaic" class="template-mosaic" hidden></div>
 
   {% comment %}
     Absolute, matching the nav's own Create links. A relative /new does not
@@ -124,6 +121,15 @@
     <span>Browse all templates</span>
     <span class="browse-templates-arrow" aria-hidden="true">&rarr;</span>
   </a>
+
+  {% comment %}
+    Two ways forward, not a sequence: start from a template yourself, or have
+    Claude do it. Without something between them the second reads as a step
+    after the first. It fades out at both ends rather than ruling a line across
+    the column, which would divide the section rather than separate two things
+    inside it.
+  {% endcomment %}
+  <div class="build-divider" aria-hidden="true"></div>
 
   {% include "build-cta" %}
 </div>

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -93,14 +93,19 @@
     editor's templates.json. Everything that matters is already here: the
     heading, the line above, and the link below all work with no JS and no
     network, so a failed fetch leaves a section that still reads and still has
-    somewhere to go, rather than a hole.
+    somewhere to go, rather than a hole. The label is inside the hidden
+    wrapper rather than beside it, so it never introduces a grid that is not
+    there.
 
     It is a fixed window onto the catalog, not the whole of it - twelve tiles
     whatever the catalog grows to, with the remainder named in the link. A
     grid of forty thumbnails does not read as "forty templates" to anyone; a
     tidy dozen and a number does.
   {% endcomment %}
-  <div id="template-mosaic" class="template-mosaic" hidden></div>
+  <div id="featured-templates" class="featured-templates" hidden>
+    <h3 class="featured-heading">Featured templates</h3>
+    <div id="template-mosaic" class="template-mosaic"></div>
+  </div>
 
   {% comment %}
     Absolute, matching the nav's own Create links. A relative /new does not
@@ -116,7 +121,7 @@
     href="https://editor.archival.dev/new"
     data-umami-event="hero-browse-templates"
   >
-    <span id="browse-templates-label">Browse all templates</span>
+    <span>Browse all templates</span>
     <span class="browse-templates-arrow" aria-hidden="true">&rarr;</span>
   </a>
 
@@ -743,296 +748,294 @@
   {% endfor %}
 </div>
 
+{% comment %} Benefit Sections {% endcomment %}
 
-  {% comment %} Benefit Sections {% endcomment %}
-
-  <div class="benefit-grid benefit-grid--compact">
-    {% for section in home.sections %}
-      <div class="benefit" data-glow>
-        <h2 class="section-title">{{ section.title }}</h2>
-        <div class="section-content">
-          {{ section.content }}
-        </div>
+<div class="benefit-grid benefit-grid--compact">
+  {% for section in home.sections %}
+    <div class="benefit" data-glow>
+      <h2 class="section-title">{{ section.title }}</h2>
+      <div class="section-content">
+        {{ section.content }}
       </div>
-    {% endfor %}
-  </div>
+    </div>
+  {% endfor %}
+</div>
 
-  {% comment %} Manifesto CTA {% endcomment %}
+{% comment %} Manifesto CTA {% endcomment %}
 
-  <div class="md:max-w-[1200px] w-full mb-40">
-    <a href="/manifesto.html" class="manifesto-cta" data-umami-event="cta-read-manifesto"> Read the Manifesto </a>
-  </div>
+<div class="md:max-w-[1200px] w-full mb-40">
+  <a href="/manifesto.html" class="manifesto-cta" data-umami-event="cta-read-manifesto"> Read the Manifesto </a>
+</div>
 
-  {% comment %} Contact Section {% endcomment %}
+{% comment %} Contact Section {% endcomment %}
 
-  {% include "connect" %}
+{% include "connect" %}
 
-  <script>
-    (function () {
-      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+<script>
+  (function () {
+    var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-      // Uniformly scale each product frame to fit its column. The frame is laid out
-      // at a fixed design width (--pf-dw), so its internal layout never reflows; zoom
-      // scales the whole thing — content and the %-pinned callout markers alike —
-      // keeping every marker aligned to its target at any window size.
-      var rootFontPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-      var frames = [];
-      document.querySelectorAll('.product-frame-wrap').forEach(function (wrap) {
-        var frame = wrap.querySelector('.product-frame');
-        if (!frame) return;
-        var dwRaw = getComputedStyle(frame).getPropertyValue('--pf-dw').trim();
-        var dw = dwRaw.indexOf('rem') > -1 ? parseFloat(dwRaw) * rootFontPx : parseFloat(dwRaw);
-        if (dw) {
-          frames.push({ wrap: wrap, frame: frame, dw: dw });
-        }
+    // Uniformly scale each product frame to fit its column. The frame is laid out
+    // at a fixed design width (--pf-dw), so its internal layout never reflows; zoom
+    // scales the whole thing — content and the %-pinned callout markers alike —
+    // keeping every marker aligned to its target at any window size.
+    var rootFontPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    var frames = [];
+    document.querySelectorAll('.product-frame-wrap').forEach(function (wrap) {
+      var frame = wrap.querySelector('.product-frame');
+      if (!frame) return;
+      var dwRaw = getComputedStyle(frame).getPropertyValue('--pf-dw').trim();
+      var dw = dwRaw.indexOf('rem') > -1 ? parseFloat(dwRaw) * rootFontPx : parseFloat(dwRaw);
+      if (dw) {
+        frames.push({ wrap: wrap, frame: frame, dw: dw });
+      }
+    });
+    function fit() {
+      frames.forEach(function (f) {
+        var cw = f.wrap.clientWidth;
+        if (!cw) return;
+        // Never scale past the design size; only shrink to fit narrower columns.
+        f.frame.style.zoom = Math.min(1, cw / f.dw);
       });
-      function fit() {
-        frames.forEach(function (f) {
-          var cw = f.wrap.clientWidth;
-          if (!cw) return;
-          // Never scale past the design size; only shrink to fit narrower columns.
-          f.frame.style.zoom = Math.min(1, cw / f.dw);
-        });
-      }
-      fit();
-      if ('ResizeObserver' in window) {
-        var ro = new ResizeObserver(fit);
-        frames.forEach(function (f) {
-          ro.observe(f.wrap);
-        });
-      } else {
-        window.addEventListener('resize', fit);
-      }
-
-      // Reveal product sections on scroll
-      var sections = document.querySelectorAll('[data-product-section]');
-      if (reduce) {
-        sections.forEach(function (s) {
-          s.classList.add('is-visible');
-        });
-      } else if ('IntersectionObserver' in window) {
-        var io = new IntersectionObserver(
-          function (entries) {
-            entries.forEach(function (e) {
-              if (e.isIntersecting) {
-                e.target.classList.add('is-visible');
-                io.unobserve(e.target);
-              }
-            });
-          },
-          { threshold: 0.25 },
-        );
-        sections.forEach(function (s) {
-          io.observe(s);
-        });
-      } else {
-        sections.forEach(function (s) {
-          s.classList.add('is-visible');
-        });
-      }
-
-      // Cross-highlight callouts: marker <-> line <-> legend <-> target
-      sections.forEach(function (section) {
-        var frame = section.querySelector('.product-frame');
-        function setActive(n, on) {
-          section
-            .querySelectorAll('[data-callout="' + n + '"], [data-callout-target="' + n + '"]')
-            .forEach(function (el) {
-              el.classList.toggle('callout-active', on);
-            });
-          if (frame) {
-            frame.classList.toggle('is-focusing', on);
-          }
-        }
-        section.querySelectorAll('[data-callout]').forEach(function (trigger) {
-          var n = trigger.getAttribute('data-callout');
-          trigger.addEventListener('mouseenter', function () {
-            setActive(n, true);
-          });
-          trigger.addEventListener('mouseleave', function () {
-            setActive(n, false);
-          });
-          trigger.addEventListener('focus', function () {
-            setActive(n, true);
-          });
-          trigger.addEventListener('blur', function () {
-            setActive(n, false);
-          });
-        });
+    }
+    fit();
+    if ('ResizeObserver' in window) {
+      var ro = new ResizeObserver(fit);
+      frames.forEach(function (f) {
+        ro.observe(f.wrap);
       });
+    } else {
+      window.addEventListener('resize', fit);
+    }
 
-      // Scroll-spy the nav's Product item: lit while the tour is the thing you're
-      // looking at, dark otherwise. The rootMargin collapses the viewport to a thin
-      // band at its middle, so the state flips as the tour crosses the centre line
-      // rather than the moment its first pixel appears.
-      var navProduct = document.querySelectorAll('[data-nav-product]');
-      var tour = document.getElementById('product');
-      if (navProduct.length && tour && 'IntersectionObserver' in window) {
-        new IntersectionObserver(
-          function (entries) {
-            entries.forEach(function (e) {
-              navProduct.forEach(function (item) {
-                item.classList.toggle('nav-active', e.isIntersecting);
-              });
-            });
-          },
-          { rootMargin: '-45% 0px -45% 0px' },
-        ).observe(tour);
-      }
-
-      // In-page nav: the tour anchor and the logo both move within this document
-      // rather than loading one. Without taking these over, "/#product" and "/" are
-      // each a *different* document from "/index.html", so the browser reloads the
-      // whole page and only then lands — which reads as a stall followed by a snap.
-      var navOffset = tour ? parseFloat(getComputedStyle(tour).scrollMarginTop) || 0 : 0;
-      var mobileMenu = document.getElementById('mobile-menu');
-      var menuClose = document.getElementById('menu-open');
-
-      // Leave modified clicks alone so open-in-new-tab still works.
-      function plainClick(e) {
-        return !(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0);
-      }
-
-      // The mobile menu only dismisses via its own X or the backdrop, so a
-      // same-document move would otherwise scroll the page behind an open menu.
-      function closeMobileMenu() {
-        if (mobileMenu && menuClose && !mobileMenu.classList.contains('hidden')) {
-          menuClose.click();
-        }
-      }
-
-      // Duration is capped so a long page doesn't mean a long wait; reduced motion
-      // gets the destination with no travel.
-      function scrollToY(targetY) {
-        var startY = window.scrollY;
-        var dy = targetY - startY;
-        if (reduce || !dy) {
-          window.scrollTo(0, targetY);
-          return;
-        }
-        var dur = Math.min(600, Math.max(280, Math.abs(dy) * 0.25));
-        var t0 = null;
-        requestAnimationFrame(function step(ts) {
-          if (t0 === null) t0 = ts;
-          var p = Math.min(1, (ts - t0) / dur);
-          var eased = p < 0.5 ? 4 * p * p * p : 1 - Math.pow(-2 * p + 2, 3) / 2;
-          window.scrollTo(0, startY + dy * eased);
-          if (p < 1) requestAnimationFrame(step);
-        });
-      }
-
-      function takeOver(links, getTargetY, url) {
-        links.forEach(function (link) {
-          // umami (public/umami.js) installs a capture-phase listener on document:
-          // for any <a data-umami-event> it calls preventDefault itself, awaits its
-          // tracking request, then assigns location.href — a script-initiated
-          // navigation ours cannot cancel, and the reason clicking these used to
-          // stall and then snap. Take the attribute off and report the event here,
-          // so the analytics still land and the navigation stays ours. Anything
-          // still carrying the attribute (every other page) is untouched.
-          var event = link.getAttribute('data-umami-event');
-          if (event) link.removeAttribute('data-umami-event');
-
-          link.addEventListener('click', function (e) {
-            if (!plainClick(e)) return;
-            e.preventDefault();
-            if (event && typeof umami !== 'undefined') umami.track(event);
-            closeMobileMenu();
-            history.replaceState(null, '', url);
-            scrollToY(getTargetY());
+    // Reveal product sections on scroll
+    var sections = document.querySelectorAll('[data-product-section]');
+    if (reduce) {
+      sections.forEach(function (s) {
+        s.classList.add('is-visible');
+      });
+    } else if ('IntersectionObserver' in window) {
+      var io = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (e) {
+            if (e.isIntersecting) {
+              e.target.classList.add('is-visible');
+              io.unobserve(e.target);
+            }
           });
-        });
-      }
-
-      var tourLinks = document.querySelectorAll('a[href="#product"], a[href="/#product"]');
-      if (tour && tourLinks.length) {
-        takeOver(
-          tourLinks,
-          function () {
-            return Math.round(tour.getBoundingClientRect().top + window.scrollY - navOffset);
-          },
-          '#product',
-        );
-      }
-
-      // The logo already means "home" — on the homepage that's the top of this page.
-      // Dropping the hash keeps the URL honest about where the reader ended up.
-      takeOver(
-        document.querySelectorAll('#logo a'),
-        function () {
-          return 0;
         },
-        location.pathname + location.search,
+        { threshold: 0.25 },
       );
-
-      if (reduce) return;
-
-      // Benefit cards track the pointer to place their hover glow, but do not tilt:
-      // at a quarter of their former size the tilt read as jitter, and the row's job
-      // this late in the page is to sit still.
-      document.querySelectorAll('[data-glow]').forEach(function (card) {
-        var bounds;
-        card.addEventListener('mouseenter', function () {
-          bounds = card.getBoundingClientRect();
-        });
-        card.addEventListener('mousemove', function (e) {
-          if (!bounds) return;
-          card.style.setProperty('--mouse-x', ((e.clientX - bounds.left) / bounds.width) * 100 + '%');
-          card.style.setProperty('--mouse-y', ((e.clientY - bounds.top) / bounds.height) * 100 + '%');
-        });
-        card.addEventListener('mouseleave', function () {
-          card.style.setProperty('--mouse-x', '50%');
-          card.style.setProperty('--mouse-y', '50%');
-        });
+      sections.forEach(function (s) {
+        io.observe(s);
       });
-
-      // 3D tilt on product frames
-      document.querySelectorAll('.product-frame-wrap[data-tilt]').forEach(function (card) {
-        var frame = card.querySelector('.product-frame');
-        if (!frame) return;
-        var maxTilt = 6,
-          bounds;
-        card.addEventListener('mouseenter', function () {
-          bounds = frame.getBoundingClientRect();
-          frame.style.transition = 'none';
-        });
-        card.addEventListener('mousemove', function (e) {
-          if (!bounds) return;
-          var mx = e.clientX - bounds.left,
-            my = e.clientY - bounds.top;
-          var rx = ((my - bounds.height / 2) / (bounds.height / 2)) * -maxTilt;
-          var ry = ((mx - bounds.width / 2) / (bounds.width / 2)) * maxTilt;
-          frame.style.transform = 'perspective(1200px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
-        });
-        card.addEventListener('mouseleave', function () {
-          frame.style.transition = 'transform 0.4s ease-out';
-          frame.style.transform = 'perspective(1200px) rotateX(0) rotateY(0)';
-        });
+    } else {
+      sections.forEach(function (s) {
+        s.classList.add('is-visible');
       });
+    }
 
-      // Hero tilt, bound once. Both source pages registered their own mousemove
-      // handler for [data-tilt-hero]; merged naively that was two handlers writing
-      // conflicting transforms to the same element.
-      var heroMaxTilt = 12,
-        heroPerspective = 1200;
-      var heroes = document.querySelectorAll('[data-tilt-hero]');
-      if (heroes.length) {
-        document.addEventListener('mousemove', function (e) {
-          var rx = ((e.clientY - window.innerHeight / 2) / (window.innerHeight / 2)) * -heroMaxTilt;
-          var ry = ((e.clientX - window.innerWidth / 2) / (window.innerWidth / 2)) * heroMaxTilt;
-          heroes.forEach(function (hero) {
-            hero.style.setProperty('--hero-mouse-x', (e.clientX / window.innerWidth) * 100 + '%');
-            hero.style.setProperty('--hero-mouse-y', (e.clientY / window.innerHeight) * 100 + '%');
-            hero.style.transform =
-              'perspective(' + heroPerspective + 'px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
+    // Cross-highlight callouts: marker <-> line <-> legend <-> target
+    sections.forEach(function (section) {
+      var frame = section.querySelector('.product-frame');
+      function setActive(n, on) {
+        section
+          .querySelectorAll('[data-callout="' + n + '"], [data-callout-target="' + n + '"]')
+          .forEach(function (el) {
+            el.classList.toggle('callout-active', on);
           });
-        });
-        document.addEventListener('mouseleave', function () {
-          heroes.forEach(function (hero) {
-            hero.style.transition = 'transform 0.5s ease-out';
-            hero.style.transform = 'perspective(1200px) rotateX(0deg) rotateY(0deg)';
-          });
-        });
+        if (frame) {
+          frame.classList.toggle('is-focusing', on);
+        }
       }
-    })();
-  </script>
+      section.querySelectorAll('[data-callout]').forEach(function (trigger) {
+        var n = trigger.getAttribute('data-callout');
+        trigger.addEventListener('mouseenter', function () {
+          setActive(n, true);
+        });
+        trigger.addEventListener('mouseleave', function () {
+          setActive(n, false);
+        });
+        trigger.addEventListener('focus', function () {
+          setActive(n, true);
+        });
+        trigger.addEventListener('blur', function () {
+          setActive(n, false);
+        });
+      });
+    });
+
+    // Scroll-spy the nav's Product item: lit while the tour is the thing you're
+    // looking at, dark otherwise. The rootMargin collapses the viewport to a thin
+    // band at its middle, so the state flips as the tour crosses the centre line
+    // rather than the moment its first pixel appears.
+    var navProduct = document.querySelectorAll('[data-nav-product]');
+    var tour = document.getElementById('product');
+    if (navProduct.length && tour && 'IntersectionObserver' in window) {
+      new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (e) {
+            navProduct.forEach(function (item) {
+              item.classList.toggle('nav-active', e.isIntersecting);
+            });
+          });
+        },
+        { rootMargin: '-45% 0px -45% 0px' },
+      ).observe(tour);
+    }
+
+    // In-page nav: the tour anchor and the logo both move within this document
+    // rather than loading one. Without taking these over, "/#product" and "/" are
+    // each a *different* document from "/index.html", so the browser reloads the
+    // whole page and only then lands — which reads as a stall followed by a snap.
+    var navOffset = tour ? parseFloat(getComputedStyle(tour).scrollMarginTop) || 0 : 0;
+    var mobileMenu = document.getElementById('mobile-menu');
+    var menuClose = document.getElementById('menu-open');
+
+    // Leave modified clicks alone so open-in-new-tab still works.
+    function plainClick(e) {
+      return !(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0);
+    }
+
+    // The mobile menu only dismisses via its own X or the backdrop, so a
+    // same-document move would otherwise scroll the page behind an open menu.
+    function closeMobileMenu() {
+      if (mobileMenu && menuClose && !mobileMenu.classList.contains('hidden')) {
+        menuClose.click();
+      }
+    }
+
+    // Duration is capped so a long page doesn't mean a long wait; reduced motion
+    // gets the destination with no travel.
+    function scrollToY(targetY) {
+      var startY = window.scrollY;
+      var dy = targetY - startY;
+      if (reduce || !dy) {
+        window.scrollTo(0, targetY);
+        return;
+      }
+      var dur = Math.min(600, Math.max(280, Math.abs(dy) * 0.25));
+      var t0 = null;
+      requestAnimationFrame(function step(ts) {
+        if (t0 === null) t0 = ts;
+        var p = Math.min(1, (ts - t0) / dur);
+        var eased = p < 0.5 ? 4 * p * p * p : 1 - Math.pow(-2 * p + 2, 3) / 2;
+        window.scrollTo(0, startY + dy * eased);
+        if (p < 1) requestAnimationFrame(step);
+      });
+    }
+
+    function takeOver(links, getTargetY, url) {
+      links.forEach(function (link) {
+        // umami (public/umami.js) installs a capture-phase listener on document:
+        // for any <a data-umami-event> it calls preventDefault itself, awaits its
+        // tracking request, then assigns location.href — a script-initiated
+        // navigation ours cannot cancel, and the reason clicking these used to
+        // stall and then snap. Take the attribute off and report the event here,
+        // so the analytics still land and the navigation stays ours. Anything
+        // still carrying the attribute (every other page) is untouched.
+        var event = link.getAttribute('data-umami-event');
+        if (event) link.removeAttribute('data-umami-event');
+
+        link.addEventListener('click', function (e) {
+          if (!plainClick(e)) return;
+          e.preventDefault();
+          if (event && typeof umami !== 'undefined') umami.track(event);
+          closeMobileMenu();
+          history.replaceState(null, '', url);
+          scrollToY(getTargetY());
+        });
+      });
+    }
+
+    var tourLinks = document.querySelectorAll('a[href="#product"], a[href="/#product"]');
+    if (tour && tourLinks.length) {
+      takeOver(
+        tourLinks,
+        function () {
+          return Math.round(tour.getBoundingClientRect().top + window.scrollY - navOffset);
+        },
+        '#product',
+      );
+    }
+
+    // The logo already means "home" — on the homepage that's the top of this page.
+    // Dropping the hash keeps the URL honest about where the reader ended up.
+    takeOver(
+      document.querySelectorAll('#logo a'),
+      function () {
+        return 0;
+      },
+      location.pathname + location.search,
+    );
+
+    if (reduce) return;
+
+    // Benefit cards track the pointer to place their hover glow, but do not tilt:
+    // at a quarter of their former size the tilt read as jitter, and the row's job
+    // this late in the page is to sit still.
+    document.querySelectorAll('[data-glow]').forEach(function (card) {
+      var bounds;
+      card.addEventListener('mouseenter', function () {
+        bounds = card.getBoundingClientRect();
+      });
+      card.addEventListener('mousemove', function (e) {
+        if (!bounds) return;
+        card.style.setProperty('--mouse-x', ((e.clientX - bounds.left) / bounds.width) * 100 + '%');
+        card.style.setProperty('--mouse-y', ((e.clientY - bounds.top) / bounds.height) * 100 + '%');
+      });
+      card.addEventListener('mouseleave', function () {
+        card.style.setProperty('--mouse-x', '50%');
+        card.style.setProperty('--mouse-y', '50%');
+      });
+    });
+
+    // 3D tilt on product frames
+    document.querySelectorAll('.product-frame-wrap[data-tilt]').forEach(function (card) {
+      var frame = card.querySelector('.product-frame');
+      if (!frame) return;
+      var maxTilt = 6,
+        bounds;
+      card.addEventListener('mouseenter', function () {
+        bounds = frame.getBoundingClientRect();
+        frame.style.transition = 'none';
+      });
+      card.addEventListener('mousemove', function (e) {
+        if (!bounds) return;
+        var mx = e.clientX - bounds.left,
+          my = e.clientY - bounds.top;
+        var rx = ((my - bounds.height / 2) / (bounds.height / 2)) * -maxTilt;
+        var ry = ((mx - bounds.width / 2) / (bounds.width / 2)) * maxTilt;
+        frame.style.transform = 'perspective(1200px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
+      });
+      card.addEventListener('mouseleave', function () {
+        frame.style.transition = 'transform 0.4s ease-out';
+        frame.style.transform = 'perspective(1200px) rotateX(0) rotateY(0)';
+      });
+    });
+
+    // Hero tilt, bound once. Both source pages registered their own mousemove
+    // handler for [data-tilt-hero]; merged naively that was two handlers writing
+    // conflicting transforms to the same element.
+    var heroMaxTilt = 12,
+      heroPerspective = 1200;
+    var heroes = document.querySelectorAll('[data-tilt-hero]');
+    if (heroes.length) {
+      document.addEventListener('mousemove', function (e) {
+        var rx = ((e.clientY - window.innerHeight / 2) / (window.innerHeight / 2)) * -heroMaxTilt;
+        var ry = ((e.clientX - window.innerWidth / 2) / (window.innerWidth / 2)) * heroMaxTilt;
+        heroes.forEach(function (hero) {
+          hero.style.setProperty('--hero-mouse-x', (e.clientX / window.innerWidth) * 100 + '%');
+          hero.style.setProperty('--hero-mouse-y', (e.clientY / window.innerHeight) * 100 + '%');
+          hero.style.transform = 'perspective(' + heroPerspective + 'px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
+        });
+      });
+      document.addEventListener('mouseleave', function () {
+        heroes.forEach(function (hero) {
+          hero.style.transition = 'transform 0.5s ease-out';
+          hero.style.transform = 'perspective(1200px) rotateX(0deg) rotateY(0deg)';
+        });
+      });
+    }
+  })();
+</script>

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -82,36 +82,10 @@
 {% comment %} Build Section {% endcomment %}
 
 <div class="build-section">
-  {% comment %}
-    One line between the hero and the grid, not three. It used to be this
-    heading, a two-line description and a "Featured templates" label stacked on
-    each other, which is a lot of talking in front of twelve screenshots that
-    say it themselves. "yours" is picked up from "websites for everyone"
-    directly above, so the two read as one thought rather than two headings.
-  {% endcomment %}
   <h2 class="build-heading">Build yours right now.</h2>
 
-  {% comment %}
-    The mosaic is filled in by setupTemplateMosaic() in src/index.ts from the
-    editor's templates.json. Everything that matters is already here: the
-    heading, the line above, and the link below all work with no JS and no
-    network, so a failed fetch leaves a section that still reads and still has
-    somewhere to go, rather than a hole.
-
-    It is a fixed window onto the catalog, not the whole of it - twelve tiles
-    whatever the catalog grows to. Which twelve is authored in the editor's
-    objects/templates/*.toml; see MOSAIC_TILES in src/index.ts.
-  {% endcomment %}
   <div id="template-mosaic" class="template-mosaic" hidden></div>
 
-  {% comment %}
-    Absolute, matching the nav's own Create links. A relative /new does not
-    reach the gallery: unmatched paths on this site fall back to index.html
-    with a 200, so it would quietly serve the home page again rather than 404.
-    src/index.ts repoints this at whichever editor the build targets, so local
-    and staging go to their own; this value is the one that is right with no JS
-    at all.
-  {% endcomment %}
   <a
     id="browse-templates"
     class="browse-templates"
@@ -122,13 +96,6 @@
     <span class="browse-templates-arrow" aria-hidden="true">&rarr;</span>
   </a>
 
-  {% comment %}
-    Two ways forward, not a sequence: start from a template yourself, or have
-    Claude do it. Without something between them the second reads as a step
-    after the first. It fades out at both ends rather than ruling a line across
-    the column, which would divide the section rather than separate two things
-    inside it.
-  {% endcomment %}
   <div class="build-divider" aria-hidden="true"></div>
 
   {% include "build-cta" %}
@@ -318,10 +285,7 @@
             The flow this draws: choose a template, optionally say something
             about your site, generate. Built from the same .pf-* primitives the
             other frames use rather than a vocabulary of its own: the optional
-            box IS .pf-prompt-card, unchanged. That reuse is true to the
-            product - describing your site moved from being the way in to being
-            one thing you can do once you have picked, so it should read as the
-            same control, demoted.
+            box IS .pf-prompt-card, unchanged.
 
             Every element in here carries a number. A detail view of the picked
             template was drawn here once and was the only thing that did not,

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -84,10 +84,33 @@
 <div class="build-section">
   <h2 class="build-heading">Build yours right now.</h2>
   <p class="build-description">
-    Describe what type of site you'd like to create and<br class="build-description-break" />
-    we'll get you live in a few minutes.
+    Pick a template and make it yours.<br class="build-description-break" />
+    You can change all of it later.
   </p>
-  <iframe id="generate-frame"></iframe>
+
+  {% comment %}
+    The mosaic is filled in by setupTemplateMosaic() in src/index.ts from the
+    editor's templates.json. Everything that matters is already here: the
+    heading, the line above, and the link below all work with no JS and no
+    network, so a failed fetch leaves a section that still reads and still has
+    somewhere to go, rather than a hole.
+
+    It is a fixed window onto the catalog, not the whole of it - twelve tiles
+    whatever the catalog grows to, with the remainder named in the link. A
+    grid of forty thumbnails does not read as "forty templates" to anyone; a
+    tidy dozen and a number does.
+  {% endcomment %}
+  <div id="template-mosaic" class="template-mosaic" hidden></div>
+
+  <a
+    id="browse-templates"
+    class="browse-templates"
+    href="/new"
+    data-umami-event="hero-browse-templates"
+  >
+    <span id="browse-templates-label">Browse all templates</span>
+    <span class="browse-templates-arrow" aria-hidden="true">&rarr;</span>
+  </a>
 
   {% include "build-cta" %}
 </div>

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -2,7 +2,7 @@
 {% assign home = objects.home %}
 {% assign product = objects.product %}
 
-<div id="header" class="w-full flex flex-col justify-center items-center gap-6 pt-60 relative">
+<div id="header" class="w-full flex flex-col justify-center items-center gap-6 pt-44 relative">
   <h1 class="hero-message" data-tilt-hero>
     <span class="hero-line-1">websites for</span>
     <span class="hero-line-2">everyone</span>

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -102,10 +102,18 @@
   {% endcomment %}
   <div id="template-mosaic" class="template-mosaic" hidden></div>
 
+  {% comment %}
+    Absolute, matching the nav's own Create links. A relative /new does not
+    reach the gallery: unmatched paths on this site fall back to index.html
+    with a 200, so it would quietly serve the home page again rather than 404.
+    src/index.ts repoints this at whichever editor the build targets, so local
+    and staging go to their own; this value is the one that is right with no JS
+    at all.
+  {% endcomment %}
   <a
     id="browse-templates"
     class="browse-templates"
-    href="/new"
+    href="https://editor.archival.dev/new"
     data-umami-event="hero-browse-templates"
   >
     <span id="browse-templates-label">Browse all templates</span>
@@ -735,294 +743,296 @@
   {% endfor %}
 </div>
 
-{% comment %} Benefit Sections {% endcomment %}
 
-<div class="benefit-grid benefit-grid--compact">
-  {% for section in home.sections %}
-    <div class="benefit" data-glow>
-      <h2 class="section-title">{{ section.title }}</h2>
-      <div class="section-content">
-        {{ section.content }}
+  {% comment %} Benefit Sections {% endcomment %}
+
+  <div class="benefit-grid benefit-grid--compact">
+    {% for section in home.sections %}
+      <div class="benefit" data-glow>
+        <h2 class="section-title">{{ section.title }}</h2>
+        <div class="section-content">
+          {{ section.content }}
+        </div>
       </div>
-    </div>
-  {% endfor %}
-</div>
+    {% endfor %}
+  </div>
 
-{% comment %} Manifesto CTA {% endcomment %}
+  {% comment %} Manifesto CTA {% endcomment %}
 
-<div class="md:max-w-[1200px] w-full mb-40">
-  <a href="/manifesto.html" class="manifesto-cta" data-umami-event="cta-read-manifesto"> Read the Manifesto </a>
-</div>
+  <div class="md:max-w-[1200px] w-full mb-40">
+    <a href="/manifesto.html" class="manifesto-cta" data-umami-event="cta-read-manifesto"> Read the Manifesto </a>
+  </div>
 
-{% comment %} Contact Section {% endcomment %}
+  {% comment %} Contact Section {% endcomment %}
 
-{% include "connect" %}
+  {% include "connect" %}
 
-<script>
-  (function () {
-    var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  <script>
+    (function () {
+      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    // Uniformly scale each product frame to fit its column. The frame is laid out
-    // at a fixed design width (--pf-dw), so its internal layout never reflows; zoom
-    // scales the whole thing — content and the %-pinned callout markers alike —
-    // keeping every marker aligned to its target at any window size.
-    var rootFontPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-    var frames = [];
-    document.querySelectorAll('.product-frame-wrap').forEach(function (wrap) {
-      var frame = wrap.querySelector('.product-frame');
-      if (!frame) return;
-      var dwRaw = getComputedStyle(frame).getPropertyValue('--pf-dw').trim();
-      var dw = dwRaw.indexOf('rem') > -1 ? parseFloat(dwRaw) * rootFontPx : parseFloat(dwRaw);
-      if (dw) {
-        frames.push({ wrap: wrap, frame: frame, dw: dw });
+      // Uniformly scale each product frame to fit its column. The frame is laid out
+      // at a fixed design width (--pf-dw), so its internal layout never reflows; zoom
+      // scales the whole thing — content and the %-pinned callout markers alike —
+      // keeping every marker aligned to its target at any window size.
+      var rootFontPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+      var frames = [];
+      document.querySelectorAll('.product-frame-wrap').forEach(function (wrap) {
+        var frame = wrap.querySelector('.product-frame');
+        if (!frame) return;
+        var dwRaw = getComputedStyle(frame).getPropertyValue('--pf-dw').trim();
+        var dw = dwRaw.indexOf('rem') > -1 ? parseFloat(dwRaw) * rootFontPx : parseFloat(dwRaw);
+        if (dw) {
+          frames.push({ wrap: wrap, frame: frame, dw: dw });
+        }
+      });
+      function fit() {
+        frames.forEach(function (f) {
+          var cw = f.wrap.clientWidth;
+          if (!cw) return;
+          // Never scale past the design size; only shrink to fit narrower columns.
+          f.frame.style.zoom = Math.min(1, cw / f.dw);
+        });
       }
-    });
-    function fit() {
-      frames.forEach(function (f) {
-        var cw = f.wrap.clientWidth;
-        if (!cw) return;
-        // Never scale past the design size; only shrink to fit narrower columns.
-        f.frame.style.zoom = Math.min(1, cw / f.dw);
-      });
-    }
-    fit();
-    if ('ResizeObserver' in window) {
-      var ro = new ResizeObserver(fit);
-      frames.forEach(function (f) {
-        ro.observe(f.wrap);
-      });
-    } else {
-      window.addEventListener('resize', fit);
-    }
+      fit();
+      if ('ResizeObserver' in window) {
+        var ro = new ResizeObserver(fit);
+        frames.forEach(function (f) {
+          ro.observe(f.wrap);
+        });
+      } else {
+        window.addEventListener('resize', fit);
+      }
 
-    // Reveal product sections on scroll
-    var sections = document.querySelectorAll('[data-product-section]');
-    if (reduce) {
-      sections.forEach(function (s) {
-        s.classList.add('is-visible');
-      });
-    } else if ('IntersectionObserver' in window) {
-      var io = new IntersectionObserver(
-        function (entries) {
-          entries.forEach(function (e) {
-            if (e.isIntersecting) {
-              e.target.classList.add('is-visible');
-              io.unobserve(e.target);
-            }
-          });
-        },
-        { threshold: 0.25 },
-      );
-      sections.forEach(function (s) {
-        io.observe(s);
-      });
-    } else {
-      sections.forEach(function (s) {
-        s.classList.add('is-visible');
-      });
-    }
+      // Reveal product sections on scroll
+      var sections = document.querySelectorAll('[data-product-section]');
+      if (reduce) {
+        sections.forEach(function (s) {
+          s.classList.add('is-visible');
+        });
+      } else if ('IntersectionObserver' in window) {
+        var io = new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (e) {
+              if (e.isIntersecting) {
+                e.target.classList.add('is-visible');
+                io.unobserve(e.target);
+              }
+            });
+          },
+          { threshold: 0.25 },
+        );
+        sections.forEach(function (s) {
+          io.observe(s);
+        });
+      } else {
+        sections.forEach(function (s) {
+          s.classList.add('is-visible');
+        });
+      }
 
-    // Cross-highlight callouts: marker <-> line <-> legend <-> target
-    sections.forEach(function (section) {
-      var frame = section.querySelector('.product-frame');
-      function setActive(n, on) {
-        section
-          .querySelectorAll('[data-callout="' + n + '"], [data-callout-target="' + n + '"]')
-          .forEach(function (el) {
-            el.classList.toggle('callout-active', on);
+      // Cross-highlight callouts: marker <-> line <-> legend <-> target
+      sections.forEach(function (section) {
+        var frame = section.querySelector('.product-frame');
+        function setActive(n, on) {
+          section
+            .querySelectorAll('[data-callout="' + n + '"], [data-callout-target="' + n + '"]')
+            .forEach(function (el) {
+              el.classList.toggle('callout-active', on);
+            });
+          if (frame) {
+            frame.classList.toggle('is-focusing', on);
+          }
+        }
+        section.querySelectorAll('[data-callout]').forEach(function (trigger) {
+          var n = trigger.getAttribute('data-callout');
+          trigger.addEventListener('mouseenter', function () {
+            setActive(n, true);
           });
-        if (frame) {
-          frame.classList.toggle('is-focusing', on);
+          trigger.addEventListener('mouseleave', function () {
+            setActive(n, false);
+          });
+          trigger.addEventListener('focus', function () {
+            setActive(n, true);
+          });
+          trigger.addEventListener('blur', function () {
+            setActive(n, false);
+          });
+        });
+      });
+
+      // Scroll-spy the nav's Product item: lit while the tour is the thing you're
+      // looking at, dark otherwise. The rootMargin collapses the viewport to a thin
+      // band at its middle, so the state flips as the tour crosses the centre line
+      // rather than the moment its first pixel appears.
+      var navProduct = document.querySelectorAll('[data-nav-product]');
+      var tour = document.getElementById('product');
+      if (navProduct.length && tour && 'IntersectionObserver' in window) {
+        new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (e) {
+              navProduct.forEach(function (item) {
+                item.classList.toggle('nav-active', e.isIntersecting);
+              });
+            });
+          },
+          { rootMargin: '-45% 0px -45% 0px' },
+        ).observe(tour);
+      }
+
+      // In-page nav: the tour anchor and the logo both move within this document
+      // rather than loading one. Without taking these over, "/#product" and "/" are
+      // each a *different* document from "/index.html", so the browser reloads the
+      // whole page and only then lands — which reads as a stall followed by a snap.
+      var navOffset = tour ? parseFloat(getComputedStyle(tour).scrollMarginTop) || 0 : 0;
+      var mobileMenu = document.getElementById('mobile-menu');
+      var menuClose = document.getElementById('menu-open');
+
+      // Leave modified clicks alone so open-in-new-tab still works.
+      function plainClick(e) {
+        return !(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0);
+      }
+
+      // The mobile menu only dismisses via its own X or the backdrop, so a
+      // same-document move would otherwise scroll the page behind an open menu.
+      function closeMobileMenu() {
+        if (mobileMenu && menuClose && !mobileMenu.classList.contains('hidden')) {
+          menuClose.click();
         }
       }
-      section.querySelectorAll('[data-callout]').forEach(function (trigger) {
-        var n = trigger.getAttribute('data-callout');
-        trigger.addEventListener('mouseenter', function () {
-          setActive(n, true);
-        });
-        trigger.addEventListener('mouseleave', function () {
-          setActive(n, false);
-        });
-        trigger.addEventListener('focus', function () {
-          setActive(n, true);
-        });
-        trigger.addEventListener('blur', function () {
-          setActive(n, false);
-        });
-      });
-    });
 
-    // Scroll-spy the nav's Product item: lit while the tour is the thing you're
-    // looking at, dark otherwise. The rootMargin collapses the viewport to a thin
-    // band at its middle, so the state flips as the tour crosses the centre line
-    // rather than the moment its first pixel appears.
-    var navProduct = document.querySelectorAll('[data-nav-product]');
-    var tour = document.getElementById('product');
-    if (navProduct.length && tour && 'IntersectionObserver' in window) {
-      new IntersectionObserver(
-        function (entries) {
-          entries.forEach(function (e) {
-            navProduct.forEach(function (item) {
-              item.classList.toggle('nav-active', e.isIntersecting);
-            });
+      // Duration is capped so a long page doesn't mean a long wait; reduced motion
+      // gets the destination with no travel.
+      function scrollToY(targetY) {
+        var startY = window.scrollY;
+        var dy = targetY - startY;
+        if (reduce || !dy) {
+          window.scrollTo(0, targetY);
+          return;
+        }
+        var dur = Math.min(600, Math.max(280, Math.abs(dy) * 0.25));
+        var t0 = null;
+        requestAnimationFrame(function step(ts) {
+          if (t0 === null) t0 = ts;
+          var p = Math.min(1, (ts - t0) / dur);
+          var eased = p < 0.5 ? 4 * p * p * p : 1 - Math.pow(-2 * p + 2, 3) / 2;
+          window.scrollTo(0, startY + dy * eased);
+          if (p < 1) requestAnimationFrame(step);
+        });
+      }
+
+      function takeOver(links, getTargetY, url) {
+        links.forEach(function (link) {
+          // umami (public/umami.js) installs a capture-phase listener on document:
+          // for any <a data-umami-event> it calls preventDefault itself, awaits its
+          // tracking request, then assigns location.href — a script-initiated
+          // navigation ours cannot cancel, and the reason clicking these used to
+          // stall and then snap. Take the attribute off and report the event here,
+          // so the analytics still land and the navigation stays ours. Anything
+          // still carrying the attribute (every other page) is untouched.
+          var event = link.getAttribute('data-umami-event');
+          if (event) link.removeAttribute('data-umami-event');
+
+          link.addEventListener('click', function (e) {
+            if (!plainClick(e)) return;
+            e.preventDefault();
+            if (event && typeof umami !== 'undefined') umami.track(event);
+            closeMobileMenu();
+            history.replaceState(null, '', url);
+            scrollToY(getTargetY());
           });
-        },
-        { rootMargin: '-45% 0px -45% 0px' },
-      ).observe(tour);
-    }
-
-    // In-page nav: the tour anchor and the logo both move within this document
-    // rather than loading one. Without taking these over, "/#product" and "/" are
-    // each a *different* document from "/index.html", so the browser reloads the
-    // whole page and only then lands — which reads as a stall followed by a snap.
-    var navOffset = tour ? parseFloat(getComputedStyle(tour).scrollMarginTop) || 0 : 0;
-    var mobileMenu = document.getElementById('mobile-menu');
-    var menuClose = document.getElementById('menu-open');
-
-    // Leave modified clicks alone so open-in-new-tab still works.
-    function plainClick(e) {
-      return !(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0);
-    }
-
-    // The mobile menu only dismisses via its own X or the backdrop, so a
-    // same-document move would otherwise scroll the page behind an open menu.
-    function closeMobileMenu() {
-      if (mobileMenu && menuClose && !mobileMenu.classList.contains('hidden')) {
-        menuClose.click();
-      }
-    }
-
-    // Duration is capped so a long page doesn't mean a long wait; reduced motion
-    // gets the destination with no travel.
-    function scrollToY(targetY) {
-      var startY = window.scrollY;
-      var dy = targetY - startY;
-      if (reduce || !dy) {
-        window.scrollTo(0, targetY);
-        return;
-      }
-      var dur = Math.min(600, Math.max(280, Math.abs(dy) * 0.25));
-      var t0 = null;
-      requestAnimationFrame(function step(ts) {
-        if (t0 === null) t0 = ts;
-        var p = Math.min(1, (ts - t0) / dur);
-        var eased = p < 0.5 ? 4 * p * p * p : 1 - Math.pow(-2 * p + 2, 3) / 2;
-        window.scrollTo(0, startY + dy * eased);
-        if (p < 1) requestAnimationFrame(step);
-      });
-    }
-
-    function takeOver(links, getTargetY, url) {
-      links.forEach(function (link) {
-        // umami (public/umami.js) installs a capture-phase listener on document:
-        // for any <a data-umami-event> it calls preventDefault itself, awaits its
-        // tracking request, then assigns location.href — a script-initiated
-        // navigation ours cannot cancel, and the reason clicking these used to
-        // stall and then snap. Take the attribute off and report the event here,
-        // so the analytics still land and the navigation stays ours. Anything
-        // still carrying the attribute (every other page) is untouched.
-        var event = link.getAttribute('data-umami-event');
-        if (event) link.removeAttribute('data-umami-event');
-
-        link.addEventListener('click', function (e) {
-          if (!plainClick(e)) return;
-          e.preventDefault();
-          if (event && typeof umami !== 'undefined') umami.track(event);
-          closeMobileMenu();
-          history.replaceState(null, '', url);
-          scrollToY(getTargetY());
         });
-      });
-    }
+      }
 
-    var tourLinks = document.querySelectorAll('a[href="#product"], a[href="/#product"]');
-    if (tour && tourLinks.length) {
+      var tourLinks = document.querySelectorAll('a[href="#product"], a[href="/#product"]');
+      if (tour && tourLinks.length) {
+        takeOver(
+          tourLinks,
+          function () {
+            return Math.round(tour.getBoundingClientRect().top + window.scrollY - navOffset);
+          },
+          '#product',
+        );
+      }
+
+      // The logo already means "home" — on the homepage that's the top of this page.
+      // Dropping the hash keeps the URL honest about where the reader ended up.
       takeOver(
-        tourLinks,
+        document.querySelectorAll('#logo a'),
         function () {
-          return Math.round(tour.getBoundingClientRect().top + window.scrollY - navOffset);
+          return 0;
         },
-        '#product',
+        location.pathname + location.search,
       );
-    }
 
-    // The logo already means "home" — on the homepage that's the top of this page.
-    // Dropping the hash keeps the URL honest about where the reader ended up.
-    takeOver(
-      document.querySelectorAll('#logo a'),
-      function () {
-        return 0;
-      },
-      location.pathname + location.search,
-    );
+      if (reduce) return;
 
-    if (reduce) return;
-
-    // Benefit cards track the pointer to place their hover glow, but do not tilt:
-    // at a quarter of their former size the tilt read as jitter, and the row's job
-    // this late in the page is to sit still.
-    document.querySelectorAll('[data-glow]').forEach(function (card) {
-      var bounds;
-      card.addEventListener('mouseenter', function () {
-        bounds = card.getBoundingClientRect();
-      });
-      card.addEventListener('mousemove', function (e) {
-        if (!bounds) return;
-        card.style.setProperty('--mouse-x', ((e.clientX - bounds.left) / bounds.width) * 100 + '%');
-        card.style.setProperty('--mouse-y', ((e.clientY - bounds.top) / bounds.height) * 100 + '%');
-      });
-      card.addEventListener('mouseleave', function () {
-        card.style.setProperty('--mouse-x', '50%');
-        card.style.setProperty('--mouse-y', '50%');
-      });
-    });
-
-    // 3D tilt on product frames
-    document.querySelectorAll('.product-frame-wrap[data-tilt]').forEach(function (card) {
-      var frame = card.querySelector('.product-frame');
-      if (!frame) return;
-      var maxTilt = 6,
-        bounds;
-      card.addEventListener('mouseenter', function () {
-        bounds = frame.getBoundingClientRect();
-        frame.style.transition = 'none';
-      });
-      card.addEventListener('mousemove', function (e) {
-        if (!bounds) return;
-        var mx = e.clientX - bounds.left,
-          my = e.clientY - bounds.top;
-        var rx = ((my - bounds.height / 2) / (bounds.height / 2)) * -maxTilt;
-        var ry = ((mx - bounds.width / 2) / (bounds.width / 2)) * maxTilt;
-        frame.style.transform = 'perspective(1200px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
-      });
-      card.addEventListener('mouseleave', function () {
-        frame.style.transition = 'transform 0.4s ease-out';
-        frame.style.transform = 'perspective(1200px) rotateX(0) rotateY(0)';
-      });
-    });
-
-    // Hero tilt, bound once. Both source pages registered their own mousemove
-    // handler for [data-tilt-hero]; merged naively that was two handlers writing
-    // conflicting transforms to the same element.
-    var heroMaxTilt = 12,
-      heroPerspective = 1200;
-    var heroes = document.querySelectorAll('[data-tilt-hero]');
-    if (heroes.length) {
-      document.addEventListener('mousemove', function (e) {
-        var rx = ((e.clientY - window.innerHeight / 2) / (window.innerHeight / 2)) * -heroMaxTilt;
-        var ry = ((e.clientX - window.innerWidth / 2) / (window.innerWidth / 2)) * heroMaxTilt;
-        heroes.forEach(function (hero) {
-          hero.style.setProperty('--hero-mouse-x', (e.clientX / window.innerWidth) * 100 + '%');
-          hero.style.setProperty('--hero-mouse-y', (e.clientY / window.innerHeight) * 100 + '%');
-          hero.style.transform = 'perspective(' + heroPerspective + 'px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
+      // Benefit cards track the pointer to place their hover glow, but do not tilt:
+      // at a quarter of their former size the tilt read as jitter, and the row's job
+      // this late in the page is to sit still.
+      document.querySelectorAll('[data-glow]').forEach(function (card) {
+        var bounds;
+        card.addEventListener('mouseenter', function () {
+          bounds = card.getBoundingClientRect();
+        });
+        card.addEventListener('mousemove', function (e) {
+          if (!bounds) return;
+          card.style.setProperty('--mouse-x', ((e.clientX - bounds.left) / bounds.width) * 100 + '%');
+          card.style.setProperty('--mouse-y', ((e.clientY - bounds.top) / bounds.height) * 100 + '%');
+        });
+        card.addEventListener('mouseleave', function () {
+          card.style.setProperty('--mouse-x', '50%');
+          card.style.setProperty('--mouse-y', '50%');
         });
       });
-      document.addEventListener('mouseleave', function () {
-        heroes.forEach(function (hero) {
-          hero.style.transition = 'transform 0.5s ease-out';
-          hero.style.transform = 'perspective(1200px) rotateX(0deg) rotateY(0deg)';
+
+      // 3D tilt on product frames
+      document.querySelectorAll('.product-frame-wrap[data-tilt]').forEach(function (card) {
+        var frame = card.querySelector('.product-frame');
+        if (!frame) return;
+        var maxTilt = 6,
+          bounds;
+        card.addEventListener('mouseenter', function () {
+          bounds = frame.getBoundingClientRect();
+          frame.style.transition = 'none';
+        });
+        card.addEventListener('mousemove', function (e) {
+          if (!bounds) return;
+          var mx = e.clientX - bounds.left,
+            my = e.clientY - bounds.top;
+          var rx = ((my - bounds.height / 2) / (bounds.height / 2)) * -maxTilt;
+          var ry = ((mx - bounds.width / 2) / (bounds.width / 2)) * maxTilt;
+          frame.style.transform = 'perspective(1200px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
+        });
+        card.addEventListener('mouseleave', function () {
+          frame.style.transition = 'transform 0.4s ease-out';
+          frame.style.transform = 'perspective(1200px) rotateX(0) rotateY(0)';
         });
       });
-    }
-  })();
-</script>
+
+      // Hero tilt, bound once. Both source pages registered their own mousemove
+      // handler for [data-tilt-hero]; merged naively that was two handlers writing
+      // conflicting transforms to the same element.
+      var heroMaxTilt = 12,
+        heroPerspective = 1200;
+      var heroes = document.querySelectorAll('[data-tilt-hero]');
+      if (heroes.length) {
+        document.addEventListener('mousemove', function (e) {
+          var rx = ((e.clientY - window.innerHeight / 2) / (window.innerHeight / 2)) * -heroMaxTilt;
+          var ry = ((e.clientX - window.innerWidth / 2) / (window.innerWidth / 2)) * heroMaxTilt;
+          heroes.forEach(function (hero) {
+            hero.style.setProperty('--hero-mouse-x', (e.clientX / window.innerWidth) * 100 + '%');
+            hero.style.setProperty('--hero-mouse-y', (e.clientY / window.innerHeight) * 100 + '%');
+            hero.style.transform =
+              'perspective(' + heroPerspective + 'px) rotateX(' + rx + 'deg) rotateY(' + ry + 'deg)';
+          });
+        });
+        document.addEventListener('mouseleave', function () {
+          heroes.forEach(function (hero) {
+            hero.style.transition = 'transform 0.5s ease-out';
+            hero.style.transform = 'perspective(1200px) rotateX(0deg) rotateY(0deg)';
+          });
+        });
+      }
+    })();
+  </script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,8 +213,105 @@ const setupTemplateMosaic = async () => {
   let resizeFrame: number | undefined;
   window.addEventListener("resize", () => {
     if (resizeFrame) window.clearTimeout(resizeFrame);
-    resizeFrame = window.setTimeout(refillAll, 150);
+    resizeFrame = window.setTimeout(() => {
+      refillAll();
+      measureCurve();
+    }, 150);
   });
+
+  /**
+   * The curve.
+   *
+   * The band is a screen wrapping around the viewer: flat straight ahead, and
+   * curling toward you at both ends, so a tile out at the side is nearer the
+   * camera and draws larger. A tile's transform therefore depends on where it
+   * is right now, which is why this runs per frame instead of being declared
+   * in CSS - the tiles never stop moving.
+   *
+   * Cheap on purpose. Each tile's offset within its track is measured once and
+   * cached; per frame this reads one box (the track's) and writes transforms,
+   * rather than asking the browser where two dozen moving elements are.
+   */
+  type Curved = { el: HTMLElement; centre: number };
+  let curved: { track: HTMLElement; row: HTMLElement; tiles: Curved[] }[] = [];
+  let depth = 0;
+  let turn = 0;
+
+  const measureCurve = () => {
+    const style = getComputedStyle(mosaic);
+    depth = parseFloat(style.getPropertyValue("--curve-depth")) || 0;
+    turn = parseFloat(style.getPropertyValue("--curve-turn")) || 0;
+    curved = rows.map(({ rowEl }) => {
+      const track = rowEl.querySelector(".marquee-track") as HTMLElement;
+      const trackLeft = track.getBoundingClientRect().left;
+      const tiles = [...track.children].map((child) => {
+        const el = child as HTMLElement;
+        const box = el.getBoundingClientRect();
+        return { el, centre: box.left - trackLeft + box.width / 2 };
+      });
+      return { track, row: rowEl, tiles };
+    });
+  };
+
+  const drawCurve = () => {
+    for (const { track, row, tiles } of curved) {
+      const trackLeft = track.getBoundingClientRect().left;
+      const rowBox = row.getBoundingClientRect();
+      const half = rowBox.width / 2;
+      const middle = rowBox.left + half;
+      for (const { el, centre } of tiles) {
+        // -1 at the left edge of the row, 0 dead ahead, 1 at the right edge.
+        // Clamped there: past the edge a tile is inside the fade anyway, and
+        // letting p run on squared into a translateZ that pushed tiles most of
+        // the way to the camera and blew them up to twice their size.
+        const p = Math.max(
+          -1,
+          Math.min(1, (trackLeft + centre - middle) / half),
+        );
+        // Squared, so the middle stays flat and the curve gathers at the ends
+        // rather than tilting everything a little.
+        el.style.transform = `translateZ(${(p * p * depth).toFixed(1)}px) rotateY(${(-p * turn).toFixed(2)}deg)`;
+      }
+    }
+  };
+
+  let frame = 0;
+  const run = () => {
+    drawCurve();
+    frame = requestAnimationFrame(run);
+  };
+  const stop = () => {
+    if (frame) cancelAnimationFrame(frame);
+    frame = 0;
+  };
+
+  const flat = window.matchMedia("(prefers-reduced-motion: reduce)");
+  const start = () => {
+    stop();
+    if (flat.matches) return;
+    measureCurve();
+    run();
+  };
+  start();
+  flat.addEventListener("change", start);
+
+  // Nothing to compute while the rows are off screen, and a page that keeps a
+  // rAF loop running out of view is just spending someone's battery.
+  if ("IntersectionObserver" in window) {
+    new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !flat.matches) {
+          if (!frame) {
+            measureCurve();
+            run();
+          }
+        } else {
+          stop();
+        }
+      },
+      { rootMargin: "200px" },
+    ).observe(mosaic);
+  }
 };
 
 // Factor by which to offset shadow

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,14 @@ const setupTemplateMosaic = async () => {
       return;
     }
     ({ templates } = (await response.json()) as { templates: Template[] });
-  } catch {
+  } catch (error) {
+    // Degrading quietly is right for an unreachable editor: the section still
+    // reads and the browse link still works. Saying so is right for everything
+    // else - this swallowed a ReferenceError once (a dev server holding an
+    // esbuild context from before EDITOR_URL existed, since esbuild's watch
+    // captures its defines at startup and never re-reads build.mjs) and the
+    // silence was the expensive part, not the failure.
+    console.warn("Could not load the template catalog:", error);
     return;
   }
   if (!Array.isArray(templates) || templates.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,16 @@ window.addEventListener("load", () => {
  * no JS at all leaves a section that still reads and still leads somewhere.
  */
 
-const MOSAIC_TILES = 12;
+/**
+ * Seconds a tile takes to travel its own width.
+ *
+ * The drift is stated as a speed rather than a duration so it does not depend
+ * on how many templates the catalog holds: the row is a wall of sites going
+ * past at a readable pace, and that pace is a property of the band, not of the
+ * number of tiles filling it. Expressed per tile rather than in pixels so the
+ * band still drifts faster on a large display, where the tiles are bigger.
+ */
+const SECONDS_PER_TILE = 15;
 
 /**
  * `TemplateObject::identifier()` in the editor: the five parts url-encoded and
@@ -51,6 +60,15 @@ const templateId = (t: Template) =>
   [t.repo_provider, t.repo_owner, t.repo_name, t.repo_ref, t.name]
     .map(encodeURIComponent)
     .join("/");
+
+const shuffled = <T,>(items: T[]) => {
+  const out = [...items];
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+};
 
 /** Written by the editor's cache-templates step, keyed the same way. */
 const thumbnailUrl = (t: Template) =>
@@ -138,10 +156,9 @@ const setupTemplateMosaic = async () => {
    * Fill a track so it can loop seamlessly at this width.
    *
    * The animation runs to -50%, so the first half of the track has to be at
-   * least as wide as the row - otherwise the loop drags empty space through
-   * the far end. Six tiles come to about 1536px, so anything above roughly a
-   * 1536px viewport showed a hole; the fix is to repeat the templates until a
-   * half covers the row rather than assuming one pass does.
+   * least as wide as the row, or the loop drags empty space through the far
+   * end. A small catalog on a wide display does not manage that in one pass,
+   * so the templates repeat until a half covers the row.
    *
    * Only the first pass is exposed. Everything after it is the same templates
    * again, so it is hidden from assistive tech and taken out of the tab order
@@ -169,6 +186,9 @@ const setupTemplateMosaic = async () => {
     // Complete the first half, then mirror it. -50% is then exactly one half.
     for (let i = 1; i < passes; i += 1) addHiddenPass();
     for (let i = 0; i < passes; i += 1) addHiddenPass();
+    // The keyframe is a percentage of the track, so the duration is what sets
+    // the speed, and it has to be a function of how far a half actually is.
+    track.style.animationDuration = `${passes * items.length * SECONDS_PER_TILE}s`;
   };
 
   const row = (items: Template[], reverse: boolean) => {
@@ -180,9 +200,11 @@ const setupTemplateMosaic = async () => {
     return { rowEl, refill: () => fillTrack(rowEl, track, items) };
   };
 
+  // Shuffled, so a reload is a different wall rather than the same one again -
+  // and so no template is permanently the one at the front of the catalog.
+  const featured = shuffled(templates);
   // Split across two rows that drift against each other. An odd count puts the
   // extra one on top, where the row is read first.
-  const featured = templates.slice(0, MOSAIC_TILES);
   const split = Math.ceil(featured.length / 2);
   const rows = [
     row(featured.slice(0, split), false),
@@ -212,11 +234,14 @@ const setupTemplateMosaic = async () => {
    * is right now, which is why this runs per frame instead of being declared
    * in CSS - the tiles never stop moving.
    *
-   * Cheap on purpose. Each tile's offset within its track is measured once and
-   * cached; per frame this reads one box (the track's) and writes transforms,
-   * rather than asking the browser where two dozen moving elements are.
+   * Cheap on purpose, and independent of how long the catalog is. Each tile's
+   * offset within its track is measured once and cached; per frame this reads
+   * one box (the track's) and writes transforms only for the tiles actually
+   * over the row, rather than asking the browser where every tile is. The rest
+   * of the track is clipped, so the work that matters is set by the width of
+   * the display and not by the number of templates strung across it.
    */
-  type Curved = { el: HTMLElement; centre: number };
+  type Curved = { el: HTMLElement; centre: number; radius: number };
   let curved: { track: HTMLElement; row: HTMLElement; tiles: Curved[] }[] = [];
   let depth = 0;
   let turn = 0;
@@ -225,13 +250,27 @@ const setupTemplateMosaic = async () => {
     const style = getComputedStyle(mosaic);
     depth = parseFloat(style.getPropertyValue("--curve-depth")) || 0;
     turn = parseFloat(style.getPropertyValue("--curve-turn")) || 0;
-    curved = rows.map(({ rowEl }) => {
-      const track = rowEl.querySelector(".marquee-track") as HTMLElement;
+    const tracks = rows.map(
+      ({ rowEl }) => rowEl.querySelector(".marquee-track") as HTMLElement,
+    );
+    // A tile's offset is taken from its rendered box, so any curve still on it
+    // from an earlier run would be measured in as part of where it sits.
+    for (const track of tracks) {
+      for (const child of track.children) {
+        (child as HTMLElement).style.transform = "";
+      }
+    }
+    curved = rows.map(({ rowEl }, i) => {
+      const track = tracks[i];
       const trackLeft = track.getBoundingClientRect().left;
       const tiles = [...track.children].map((child) => {
         const el = child as HTMLElement;
         const box = el.getBoundingClientRect();
-        return { el, centre: box.left - trackLeft + box.width / 2 };
+        return {
+          el,
+          centre: box.left - trackLeft + box.width / 2,
+          radius: box.width / 2,
+        };
       });
       return { track, row: rowEl, tiles };
     });
@@ -243,15 +282,17 @@ const setupTemplateMosaic = async () => {
       const rowBox = row.getBoundingClientRect();
       const half = rowBox.width / 2;
       const middle = rowBox.left + half;
-      for (const { el, centre } of tiles) {
+      for (const { el, centre, radius } of tiles) {
+        const offset = trackLeft + centre - middle;
+        // Clipped by the row, so nothing it is given would be seen. The track
+        // runs the whole catalog past a fixed window; this is what keeps the
+        // per-frame cost the size of the window rather than the catalog.
+        if (Math.abs(offset) > half + radius) continue;
         // -1 at the left edge of the row, 0 dead ahead, 1 at the right edge.
         // Clamped there: past the edge a tile is inside the fade anyway, and
         // letting p run on squared into a translateZ that pushed tiles most of
         // the way to the camera and blew them up to twice their size.
-        const p = Math.max(
-          -1,
-          Math.min(1, (trackLeft + centre - middle) / half),
-        );
+        const p = Math.max(-1, Math.min(1, offset / half));
         // Squared, so the middle stays flat and the curve gathers at the ends
         // rather than tilting everything a little.
         // depth is a fraction of the row, so the curve scales with the display

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,10 @@ const setupTemplateMosaic = async () => {
         );
         // Squared, so the middle stays flat and the curve gathers at the ends
         // rather than tilting everything a little.
-        el.style.transform = `translateZ(${(p * p * depth).toFixed(1)}px) rotateY(${(-p * turn).toFixed(2)}deg)`;
+        // depth is a fraction of the row, so the curve scales with the display
+        // the same way the tiles and the perspective do.
+        const push = p * p * depth * rowBox.width;
+        el.style.transform = `translateZ(${push.toFixed(1)}px) rotateY(${(-p * turn).toFixed(2)}deg)`;
       }
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,18 +39,6 @@ window.addEventListener("load", () => {
  * no JS at all leaves a section that still reads and still leads somewhere.
  */
 
-/**
- * How many templates are featured. The first N of the catalog, and which ones
- * those are is an editorial decision made once, in the editor's own
- * objects/templates/*.toml: each carries an `order`, archival emits
- * templates.json in it, and the gallery at /new is sorted by the same thing.
- * There is no second list to keep in step here.
- *
- * Every one of them goes past at every width - the rows carry them rather than
- * a grid trimming them - so `order` decides the sequence and which row a
- * template lands in, not whether it is seen at all. Before it existed archival
- * emitted these alphabetically by filename.
- */
 const MOSAIC_TILES = 12;
 
 /**
@@ -80,11 +68,7 @@ type Template = {
  * Send the browse link to the editor this build targets.
  *
  * The markup carries the production editor, which is what a visitor with no JS
- * needs; this is what makes local and staging reach their own. Deliberately not
- * inside setupTemplateMosaic: where the link goes has nothing to do with
- * whether the catalog loaded, and it would be a poor trade to leave the one
- * remaining way forward pointing elsewhere on exactly the runs where the tiles
- * failed to render.
+ * needs; this is what makes local and staging reach their own.
  */
 const pointBrowseLinkAtEditor = () => {
   const link = document.getElementById("browse-templates");

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,10 @@ window.addEventListener("load", () => {
  * templates.json in it, and the gallery at /new is sorted by the same thing.
  * There is no second list to keep in step here.
  *
- * The responsive rules below cut this down further - 9 tiles, then 6 - and they
- * cut from the end, so `order` decides what a phone sees, not just the sequence.
- * Before it existed archival emitted these alphabetically by filename, which
- * meant the six a phone showed were whichever templates happened to sort first.
+ * Every one of them goes past at every width - the rows carry them rather than
+ * a grid trimming them - so `order` decides the sequence and which row a
+ * template lands in, not whether it is seen at all. Before it existed archival
+ * emitted these alphabetically by filename.
  */
 const MOSAIC_TILES = 12;
 
@@ -122,11 +122,11 @@ const setupTemplateMosaic = async () => {
     return;
   }
 
-  for (const template of templates.slice(0, MOSAIC_TILES)) {
-    const tile = document.createElement("a");
-    tile.className = "template-tile";
-    tile.href = `${EDITOR_URL}/new?template=${encodeURIComponent(templateId(template))}`;
-    tile.setAttribute("data-umami-event", "hero-template-pick");
+  const tile = (template: Template) => {
+    const el = document.createElement("a");
+    el.className = "template-tile";
+    el.href = `${EDITOR_URL}/new?template=${encodeURIComponent(templateId(template))}`;
+    el.setAttribute("data-umami-event", "hero-template-pick");
 
     const shot = document.createElement("span");
     shot.className = "template-tile-shot";
@@ -139,16 +139,52 @@ const setupTemplateMosaic = async () => {
     // Thumbnails only exist once the gallery ships. Until then - and for any
     // template whose shot has not been captured - the tile falls back to its
     // name on an empty frame rather than a broken image.
-    img.addEventListener("error", () => tile.classList.add("no-shot"));
+    img.addEventListener("error", () => el.classList.add("no-shot"));
     shot.appendChild(img);
 
     const name = document.createElement("span");
     name.className = "template-tile-name";
     name.textContent = template.name;
 
-    tile.append(shot, name);
-    mosaic.appendChild(tile);
-  }
+    el.append(shot, name);
+    return el;
+  };
+
+  /**
+   * One drifting row.
+   *
+   * The track carries its templates twice. The animation runs to -50%, which is
+   * exactly the width of one copy, so the second copy is sitting where the
+   * first started when it loops and the seam never shows. The clones are hidden
+   * from assistive tech and taken out of the tab order, or every template would
+   * be announced and focusable twice.
+   */
+  const row = (items: Template[], reverse: boolean) => {
+    const rowEl = document.createElement("div");
+    rowEl.className = "marquee-row";
+    const track = document.createElement("div");
+    track.className = reverse ? "marquee-track reverse" : "marquee-track";
+    for (const template of items) {
+      track.appendChild(tile(template));
+    }
+    for (const template of items) {
+      const clone = tile(template);
+      clone.setAttribute("aria-hidden", "true");
+      clone.tabIndex = -1;
+      track.appendChild(clone);
+    }
+    rowEl.appendChild(track);
+    return rowEl;
+  };
+
+  // Split across two rows that drift against each other. An odd count puts the
+  // extra one on top, where the row is read first.
+  const featured = templates.slice(0, MOSAIC_TILES);
+  const split = Math.ceil(featured.length / 2);
+  mosaic.append(
+    row(featured.slice(0, split), false),
+    row(featured.slice(split), true),
+  );
   mosaic.hidden = false;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,19 @@ window.addEventListener("load", () => {
  * browse link are in the markup already, so a failed fetch, an empty catalog or
  * no JS at all leaves a section that still reads and still leads somewhere.
  */
+
+/**
+ * How many templates are featured. The first N of the catalog, and which ones
+ * those are is an editorial decision made once, in the editor's own
+ * objects/templates/*.toml: each carries an `order`, archival emits
+ * templates.json in it, and the gallery at /new is sorted by the same thing.
+ * There is no second list to keep in step here.
+ *
+ * The responsive rules below cut this down further - 9 tiles, then 6 - and they
+ * cut from the end, so `order` decides what a phone sees, not just the sequence.
+ * Before it existed archival emitted these alphabetically by filename, which
+ * meant the six a phone showed were whichever templates happened to sort first.
+ */
 const MOSAIC_TILES = 12;
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,41 +151,70 @@ const setupTemplateMosaic = async () => {
   };
 
   /**
-   * One drifting row.
+   * Fill a track so it can loop seamlessly at this width.
    *
-   * The track carries its templates twice. The animation runs to -50%, which is
-   * exactly the width of one copy, so the second copy is sitting where the
-   * first started when it loops and the seam never shows. The clones are hidden
-   * from assistive tech and taken out of the tab order, or every template would
-   * be announced and focusable twice.
+   * The animation runs to -50%, so the first half of the track has to be at
+   * least as wide as the row - otherwise the loop drags empty space through
+   * the far end. Six tiles come to about 1536px, so anything above roughly a
+   * 1536px viewport showed a hole; the fix is to repeat the templates until a
+   * half covers the row rather than assuming one pass does.
+   *
+   * Only the first pass is exposed. Everything after it is the same templates
+   * again, so it is hidden from assistive tech and taken out of the tab order
+   * rather than announcing and focusing each template several times.
    */
+  const fillTrack = (
+    rowEl: HTMLElement,
+    track: HTMLElement,
+    items: Template[],
+  ) => {
+    track.replaceChildren();
+    for (const template of items) {
+      track.appendChild(tile(template));
+    }
+    const passWidth = track.scrollWidth;
+    const passes = Math.max(1, Math.ceil(rowEl.clientWidth / passWidth));
+    const addHiddenPass = () => {
+      for (const template of items) {
+        const el = tile(template);
+        el.setAttribute("aria-hidden", "true");
+        el.tabIndex = -1;
+        track.appendChild(el);
+      }
+    };
+    // Complete the first half, then mirror it. -50% is then exactly one half.
+    for (let i = 1; i < passes; i += 1) addHiddenPass();
+    for (let i = 0; i < passes; i += 1) addHiddenPass();
+  };
+
   const row = (items: Template[], reverse: boolean) => {
     const rowEl = document.createElement("div");
     rowEl.className = "marquee-row";
     const track = document.createElement("div");
     track.className = reverse ? "marquee-track reverse" : "marquee-track";
-    for (const template of items) {
-      track.appendChild(tile(template));
-    }
-    for (const template of items) {
-      const clone = tile(template);
-      clone.setAttribute("aria-hidden", "true");
-      clone.tabIndex = -1;
-      track.appendChild(clone);
-    }
     rowEl.appendChild(track);
-    return rowEl;
+    return { rowEl, refill: () => fillTrack(rowEl, track, items) };
   };
 
   // Split across two rows that drift against each other. An odd count puts the
   // extra one on top, where the row is read first.
   const featured = templates.slice(0, MOSAIC_TILES);
   const split = Math.ceil(featured.length / 2);
-  mosaic.append(
+  const rows = [
     row(featured.slice(0, split), false),
     row(featured.slice(split), true),
-  );
+  ];
+  mosaic.append(...rows.map((r) => r.rowEl));
   mosaic.hidden = false;
+  // Measured, so it has to happen after the rows are laid out - and again when
+  // the window grows, or a track that covered the row stops covering it.
+  const refillAll = () => rows.forEach((r) => r.refill());
+  refillAll();
+  let resizeFrame: number | undefined;
+  window.addEventListener("resize", () => {
+    if (resizeFrame) window.clearTimeout(resizeFrame);
+    resizeFrame = window.setTimeout(refillAll, 150);
+  });
 };
 
 // Factor by which to offset shadow

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
-declare const umami: { track: (event: string, data?: Record<string, string | number>) => void } | undefined;
+declare const umami:
+  | { track: (event: string, data?: Record<string, string | number>) => void }
+  | undefined;
 
 window.addEventListener("load", () => {
-  setupGenerateFrame();
+  void setupTemplateMosaic();
   // setupHeaderVideos();
   setupMobileMenu();
   setupDocsMenu();
@@ -23,88 +25,100 @@ window.addEventListener("load", () => {
   update();
 });
 
-const setupGenerateFrame = () => {
-  // Only index and product embed the frame. Bail before anything else so pages
-  // without it don't throw and abort the rest of the load handler.
-  const iframe = document.getElementById('generate-frame') as HTMLIFrameElement | null;
-  if (!iframe) {
+/**
+ * Fill the mosaic from the editor's own catalog.
+ *
+ * templates.json is served from the editor origin with
+ * access-control-allow-origin: *, and carries the five repo fields that make up
+ * a template's identifier. That is all this needs: the identifier addresses the
+ * template in the gallery, and the same parts spell the thumbnail path.
+ *
+ * Progressive enhancement on purpose. The heading, the line under it and the
+ * browse link are in the markup already, so a failed fetch, an empty catalog or
+ * no JS at all leaves a section that still reads and still leads somewhere.
+ */
+const MOSAIC_TILES = 12;
+
+/**
+ * `TemplateObject::identifier()` in the editor: the five parts url-encoded and
+ * joined by "/". It has to be encodeURIComponent'd again into the query string,
+ * because the parts carry percent-escapes of their own - dropped in raw,
+ * URLSearchParams would decode them and the id would no longer match.
+ */
+const templateId = (t: Template) =>
+  [t.repo_provider, t.repo_owner, t.repo_name, t.repo_ref, t.name]
+    .map(encodeURIComponent)
+    .join("/");
+
+/** Written by the editor's cache-templates step, keyed the same way. */
+const thumbnailUrl = (t: Template) =>
+  `${EDITOR_URL}/${t.repo_provider}-${t.repo_owner}-${t.repo_name}-${t.repo_ref.replace(/\//g, "_")}/thumbnail.jpg`;
+
+type Template = {
+  name: string;
+  repo_provider: string;
+  repo_owner: string;
+  repo_name: string;
+  repo_ref: string;
+};
+
+const setupTemplateMosaic = async () => {
+  // Only the home page carries the mosaic. Bail before fetching anything so
+  // every other page does not pay for a request it will not use.
+  const mosaic = document.getElementById("template-mosaic");
+  if (!mosaic) {
     return;
   }
 
-  const srcOrigin = new URL(LANDING_IFRAME_URL).origin;
-  window.addEventListener('message', (event) => {
-      if (event.origin === srcOrigin) {
-        switch (Object.keys(event.data)[0]) {
-          case "resize": {
-            const h = event.data["resize"].height;
-            iframe.style.height = typeof h === "number" ? `${h}px` : h;
-            break;
-          }
-          case "start":
-            if (typeof umami !== 'undefined') umami.track('hero-generate-start');
-            animateIframeToFullscreen(iframe);
-            break;
-          case "ready":
-            window.location.href = srcOrigin + "/new";
-            break;
-        }
-      }
-    });
-
-  iframe.src = LANDING_IFRAME_URL;
-}
-
-const animateIframeToFullscreen = (iframe: HTMLIFrameElement) => {
-  // Avoid re-triggering if the transition has already started.
-  if (iframe.dataset.fullscreenAnimating === "true") {
-    return;
-  }
-  iframe.dataset.fullscreenAnimating = "true";
-
-  const rect = iframe.getBoundingClientRect();
-  const startTop = `${rect.top}px`;
-  const startLeft = `${rect.left}px`;
-  const startWidth = `${rect.width}px`;
-  const startHeight = `${rect.height}px`;
-
-  iframe.style.position = "fixed";
-  iframe.style.top = startTop;
-  iframe.style.left = startLeft;
-  iframe.style.width = startWidth;
-  iframe.style.height = startHeight;
-  iframe.style.margin = "0";
-  iframe.style.zIndex = "9999";
-
-  const animation = iframe.animate(
-    [
-      {
-        backgroundColor: "rgba(19,17,28,0)",
-        top: startTop,
-        left: startLeft,
-        width: startWidth,
-        height: startHeight,
-      },
-      {
-        backgroundColor: "rgba(19,17,28,1)",
-        top: "0px",
-        left: "0px",
-        width: "100%",
-        height: "100%",
-      },
-    ],
-    {
-      duration: 500,
-      easing: "cubic-bezier(0.2, 0.7, 0.2, 1)",
-      fill: "forwards",
+  let templates: Template[];
+  try {
+    const response = await fetch(`${EDITOR_URL}/templates.json`);
+    if (!response.ok) {
+      return;
     }
-  );
+    ({ templates } = (await response.json()) as { templates: Template[] });
+  } catch {
+    return;
+  }
+  if (!Array.isArray(templates) || templates.length === 0) {
+    return;
+  }
 
-  animation.addEventListener("finish", () => {
-    iframe.style.top = "0";
-    iframe.style.left = "0";
-    iframe.style.width = "100%";
-    iframe.style.height = "100%";
-  });
+  for (const template of templates.slice(0, MOSAIC_TILES)) {
+    const tile = document.createElement("a");
+    tile.className = "template-tile";
+    tile.href = `${EDITOR_URL}/new?template=${encodeURIComponent(templateId(template))}`;
+    tile.setAttribute("data-umami-event", "hero-template-pick");
+
+    const shot = document.createElement("span");
+    shot.className = "template-tile-shot";
+    const img = document.createElement("img");
+    img.src = thumbnailUrl(template);
+    img.loading = "lazy";
+    // Decorative: the name below already says which template this is, and a
+    // screen reader does not need to hear it twice.
+    img.alt = "";
+    // Thumbnails only exist once the gallery ships. Until then - and for any
+    // template whose shot has not been captured - the tile falls back to its
+    // name on an empty frame rather than a broken image.
+    img.addEventListener("error", () => tile.classList.add("no-shot"));
+    shot.appendChild(img);
+
+    const name = document.createElement("span");
+    name.className = "template-tile-name";
+    name.textContent = template.name;
+
+    tile.append(shot, name);
+    mosaic.appendChild(tile);
+  }
+  mosaic.hidden = false;
+
+  // The count is the part a grid cannot show. Only claim it once the catalog
+  // has actually arrived; the markup says "Browse all templates" until then.
+  const label = document.getElementById("browse-templates-label");
+  if (label) {
+    label.textContent = `Browse all ${templates.length} templates`;
+  }
 };
 
 // Factor by which to offset shadow
@@ -125,11 +139,9 @@ const updateShadowImages = () => {
 
 const setupDocsMenu = () => {
   const menuButton = document.querySelector("#mobile-current-view") as
-    | HTMLDivElement
-    | undefined;
+    HTMLDivElement | undefined;
   const menu = document.querySelector("#docs-selector") as
-    | HTMLDivElement
-    | undefined;
+    HTMLDivElement | undefined;
   if (menuButton && menu) {
     const toggleMenu = (e: Event) => {
       e.preventDefault();
@@ -179,7 +191,7 @@ const setupMobileMenu = () => {
     }, 25);
   };
   closedMenu?.addEventListener("click", () => {
-    if (typeof umami !== 'undefined') umami.track('mobile-menu-open');
+    if (typeof umami !== "undefined") umami.track("mobile-menu-open");
     toggleMenu(true);
   });
   openMenu?.addEventListener("click", () => {
@@ -197,7 +209,7 @@ type SearchResultsRaw = {
       docTitle: string;
       sectionTitle: string | null;
       content: string;
-    }
+    },
   ];
 };
 
@@ -259,11 +271,11 @@ const setupQuickSearch = async () => {
   const resultsEl = document.querySelector("#results") as HTMLUListElement;
   const emptyResult = document.querySelector("#results-empty") as HTMLLIElement;
   const notFoundResult = document.querySelector(
-    "#results-none"
+    "#results-none",
   ) as HTMLLIElement;
   const result = document.querySelector("#results-result") as HTMLLIElement;
   const input = document.querySelector(
-    "#quick-search-input"
+    "#quick-search-input",
   ) as HTMLInputElement;
   document
     .querySelector("#quick-search-button")
@@ -426,6 +438,6 @@ if (DEV) {
   console.log("Dev Mode enabled");
   // ESBuild watch
   new EventSource("/esbuild").addEventListener("change", () =>
-    location.reload()
+    location.reload(),
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,13 +136,11 @@ const setupTemplateMosaic = async () => {
     tile.append(shot, name);
     mosaic.appendChild(tile);
   }
-  mosaic.hidden = false;
-
-  // The count is the part a grid cannot show. Only claim it once the catalog
-  // has actually arrived; the markup says "Browse all templates" until then.
-  const label = document.getElementById("browse-templates-label");
-  if (label) {
-    label.textContent = `Browse all ${templates.length} templates`;
+  // The label and the grid are shown together: a "Featured templates" heading
+  // over nothing would be worse than no heading.
+  const featured = document.getElementById("featured-templates");
+  if (featured) {
+    featured.hidden = false;
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ declare const umami:
   | undefined;
 
 window.addEventListener("load", () => {
+  pointBrowseLinkAtEditor();
   void setupTemplateMosaic();
   // setupHeaderVideos();
   setupMobileMenu();
@@ -60,6 +61,23 @@ type Template = {
   repo_owner: string;
   repo_name: string;
   repo_ref: string;
+};
+
+/**
+ * Send the browse link to the editor this build targets.
+ *
+ * The markup carries the production editor, which is what a visitor with no JS
+ * needs; this is what makes local and staging reach their own. Deliberately not
+ * inside setupTemplateMosaic: where the link goes has nothing to do with
+ * whether the catalog loaded, and it would be a poor trade to leave the one
+ * remaining way forward pointing elsewhere on exactly the runs where the tiles
+ * failed to render.
+ */
+const pointBrowseLinkAtEditor = () => {
+  const link = document.getElementById("browse-templates");
+  if (link instanceof HTMLAnchorElement) {
+    link.href = `${EDITOR_URL}/new`;
+  }
 };
 
 const setupTemplateMosaic = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,12 +149,7 @@ const setupTemplateMosaic = async () => {
     tile.append(shot, name);
     mosaic.appendChild(tile);
   }
-  // The label and the grid are shown together: a "Featured templates" heading
-  // over nothing would be worse than no heading.
-  const featured = document.getElementById("featured-templates");
-  if (featured) {
-    featured.hidden = false;
-  }
+  mosaic.hidden = false;
 };
 
 // Factor by which to offset shadow

--- a/style/main.css
+++ b/style/main.css
@@ -229,14 +229,90 @@ h1,
   display: none;
 }
 
+/* Two rows drifting against each other, the treatment the professional
+   template uses for testimonials. Full-bleed on purpose: held inside the 52rem
+   column this reads as a ticker, and across the viewport it reads as a wall of
+   sites going past, which is the whole reason to move them.
+
+   Escapes the column with the standard 100vw trick rather than being moved out
+   of .build-section, so the heading and the link above and below it keep their
+   places in the section's flow. */
 .template-mosaic {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1.25rem 1rem;
-  /* Closer to the link below than to the heading above: the link is the grid's
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100vw;
+  max-width: 100vw;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  /* Closer to the link below than to the heading above: the link is the rows'
      overflow, so the two belong to each other. */
-  margin: 0 0 2rem;
+  margin-bottom: 2rem;
   text-align: left;
+}
+
+/* The mask is what keeps this from reading as content that has been cut off:
+   tiles arrive and leave rather than appearing and vanishing at a hard edge. */
+.marquee-row {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    transparent,
+    #000 13%,
+    #000 87%,
+    transparent
+  );
+  mask-image: linear-gradient(
+    90deg,
+    transparent,
+    #000 13%,
+    #000 87%,
+    transparent
+  );
+}
+
+.marquee-track {
+  display: flex;
+  gap: 1rem;
+  /* max-content, so -50% is exactly one copy of the templates. */
+  width: max-content;
+  animation: template-drift 90s linear infinite;
+}
+
+.marquee-track.reverse {
+  animation-direction: reverse;
+}
+
+/* Pausing on hover is not decoration here: every tile is a link, and reaching
+   for one that is still moving is a fight. Taken from the same treatment. */
+.marquee-row:hover .marquee-track,
+.marquee-row:focus-within .marquee-track {
+  animation-play-state: paused;
+}
+
+@keyframes template-drift {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* Standing still, the row has to stay reachable, so it becomes something you
+   can push along yourself rather than a strip with its end cut off. */
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+  }
+
+  .marquee-row {
+    overflow-x: auto;
+  }
+}
+
+.template-tile {
+  flex: 0 0 15rem;
 }
 
 /* Twelve light screenshots on a black page shout. Holding the wall back and
@@ -1847,16 +1923,10 @@ h1.pricing-title {
     padding: 8rem 2rem 2rem;
   }
 
-  /* Fewer, larger tiles rather than the same twelve shrunk: below this a
-     screenshot stops being legible enough to choose from, and six good ones
-     beat twelve unreadable ones. The count in the link still says how many
-     there really are. */
-  .template-mosaic {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .template-tile:nth-child(n + 10) {
-    display: none;
+  /* Smaller tiles rather than fewer: the row carries as many as it carries,
+     and every template still goes past. */
+  .template-tile {
+    flex-basis: 11rem;
   }
 
   .benefit-grid:not(.benefit-grid--compact),
@@ -2385,15 +2455,29 @@ input:checked + .slider::before {
 }
 
 /* Phones. Placed here rather than beside the other mosaic rules because the
-   3-column override lives in the 768px block further up: an earlier rule at
-   equal specificity would lose to it at every width this one cares about. */
+   override at 768px lives further up the file: an earlier rule at equal
+   specificity would lose to it at every width this one cares about. */
 @media (max-width: 520px) {
-  .template-mosaic {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem 0.75rem;
+  .template-tile {
+    flex-basis: 9rem;
   }
 
-  .template-tile:nth-child(n + 7) {
-    display: none;
+  .marquee-row {
+    /* Less of the row is on screen, so the fade has to be shorter or it eats
+       the tiles it is supposed to be revealing. */
+    -webkit-mask-image: linear-gradient(
+      90deg,
+      transparent,
+      #000 10%,
+      #000 90%,
+      transparent
+    );
+    mask-image: linear-gradient(
+      90deg,
+      transparent,
+      #000 10%,
+      #000 90%,
+      transparent
+    );
   }
 }

--- a/style/main.css
+++ b/style/main.css
@@ -322,6 +322,9 @@ h1,
   display: flex;
   width: max-content;
   transform-style: preserve-3d;
+  /* The duration is overwritten by src/index.ts once the track is filled: the
+     keyframe moves a percentage of the track, so holding one duration would
+     make a longer catalog drift faster. This is the no-JS floor. */
   animation: template-drift 90s linear infinite;
 }
 

--- a/style/main.css
+++ b/style/main.css
@@ -190,7 +190,9 @@ h1,
 .build-section {
   width: 100%;
   max-width: 52rem;
-  margin: 6rem auto 6rem;
+  /* Closer to the hero above than to what follows: "Build yours right now"
+     answers "websites for everyone", so the two belong together. */
+  margin: 4rem auto 6rem;
   padding: 0 2rem;
   text-align: center;
 }
@@ -255,26 +257,31 @@ h1,
    tiles arrive and leave rather than appearing and vanishing at a hard edge. */
 .marquee-row {
   overflow: hidden;
+  /* Room for what draws outside a tile: the frame's ring, and the hover scale.
+     Without it overflow:hidden clipped the top edge of every thumbnail. */
+  padding: 0.85rem 0;
   -webkit-mask-image: linear-gradient(
     90deg,
     transparent,
-    #000 13%,
-    #000 87%,
+    #000 20%,
+    #000 80%,
     transparent
   );
   mask-image: linear-gradient(
     90deg,
     transparent,
-    #000 13%,
-    #000 87%,
+    #000 20%,
+    #000 80%,
     transparent
   );
 }
 
+/* No `gap` here on purpose. With a gap, a track of 2N tiles is 2N tiles plus
+   2N-1 gaps, so half of it is half a gap short of one pass and the loop drifts
+   out of alignment. Carrying the spacing on the tiles themselves makes the
+   track exactly 2N whole units, and -50% exactly one pass. */
 .marquee-track {
   display: flex;
-  gap: 1rem;
-  /* max-content, so -50% is exactly one copy of the templates. */
   width: max-content;
   animation: template-drift 90s linear infinite;
 }
@@ -313,6 +320,7 @@ h1,
 
 .template-tile {
   flex: 0 0 15rem;
+  margin-right: 1rem;
 }
 
 /* Twelve light screenshots on a black page shout. Holding the wall back and
@@ -336,6 +344,7 @@ h1,
 .template-tile-shot {
   display: block;
   position: relative;
+  transform-origin: center;
   /* The editor captures thumbnails at 1280x960, so the box is 4:3 and the
      image never has to be letterboxed or cropped to fit it. */
   aspect-ratio: 4 / 3;
@@ -343,16 +352,29 @@ h1,
   border-radius: 0.375rem;
   background: rgba(255, 255, 255, 0.06);
   box-shadow: 0 0 0 1px var(--color-transparent-border);
-  transition: box-shadow 200ms ease;
+  transition:
+    box-shadow 200ms ease,
+    transform 200ms ease;
 }
 
 /* The site's own framing idiom, borrowed rather than invented: the same double
-   ring --style-double-border draws elsewhere, tightened to this scale. */
+   ring --style-double-border draws elsewhere, tightened to this scale. The
+   thumbnail comes with it - growing the ring alone read as the frame swelling
+   around a picture that stayed put. */
 .template-tile:hover .template-tile-shot,
 .template-tile:focus-visible .template-tile-shot {
+  transform: scale(1.06);
   box-shadow:
     0 0 0 2px var(--color-main-bg),
     0 0 0 4px var(--color-transparent-border);
+}
+
+/* Lifted over its neighbours while it is scaled, or the tile after it in the
+   row paints over the edge it just grew into. */
+.template-tile:hover,
+.template-tile:focus-visible {
+  position: relative;
+  z-index: 1;
 }
 
 .template-tile:focus-visible {
@@ -440,6 +462,12 @@ h1,
   .template-tile-name,
   .browse-templates-arrow {
     transition: none;
+  }
+
+  /* The ring still marks what is hovered; the growing does not. */
+  .template-tile:hover .template-tile-shot,
+  .template-tile:focus-visible .template-tile-shot {
+    transform: none;
   }
 }
 

--- a/style/main.css
+++ b/style/main.css
@@ -253,13 +253,30 @@ h1,
   text-align: left;
 }
 
+/* The curve. The band is treated as a screen wrapping around the viewer: flat
+   ahead of you, and curling toward you at both ends, so the tiles out at the
+   sides are nearer the camera and render larger. src/index.ts turns each tile
+   to face you by an amount set by where it currently is, which is why this has
+   to be driven per frame rather than declared here - a tile's place in the row
+   is what decides its transform, and that changes constantly.
+
+   --curve-depth is how far the ends come forward, --curve-turn how far they
+   turn to face you. Both are read by the script; tune them here. */
+.template-mosaic {
+  --curve-depth: 190px;
+  --curve-turn: 34deg;
+}
+
 /* The mask is what keeps this from reading as content that has been cut off:
    tiles arrive and leave rather than appearing and vanishing at a hard edge. */
 .marquee-row {
+  perspective: 900px;
+  perspective-origin: 50% 50%;
   overflow: hidden;
-  /* Room for what draws outside a tile: the frame's ring, and the hover scale.
+  /* Room for what draws outside a tile: the frame's ring, the hover scale, and
+     the curve, which grows the tiles out at the sides by about a quarter.
      Without it overflow:hidden clipped the top edge of every thumbnail. */
-  padding: 0.85rem 0;
+  padding: 1.9rem 0;
   -webkit-mask-image: linear-gradient(
     90deg,
     transparent,
@@ -283,6 +300,7 @@ h1,
 .marquee-track {
   display: flex;
   width: max-content;
+  transform-style: preserve-3d;
   animation: template-drift 90s linear infinite;
 }
 
@@ -315,12 +333,23 @@ h1,
 
   .marquee-row {
     overflow-x: auto;
+    perspective: none;
+  }
+
+  /* No curve when nothing moves. Its whole job is to make a moving band read
+     as wrapping past you; frozen, it is just warped thumbnails. */
+  .template-tile {
+    transform: none !important;
   }
 }
 
 .template-tile {
   flex: 0 0 15rem;
   margin-right: 1rem;
+  /* Set per frame by the curve; the tile's own box never moves, only the face
+     it presents. */
+  transform-style: preserve-3d;
+  backface-visibility: hidden;
 }
 
 /* Twelve light screenshots on a black page shout. Holding the wall back and

--- a/style/main.css
+++ b/style/main.css
@@ -218,18 +218,8 @@ h1,
   line-height: 1.6;
 }
 
-/* --- template mosaic ------------------------------------------------------
-   A fixed window onto the catalog: twelve tiles however many templates exist,
-   so the section's height is a constant rather than a function of the catalog.
-
-   The screenshots are the content here, the same bet the editor's own gallery
-   makes. Names are set quiet so the eye lands on the sites, not on a wall of
-   labels. */
-
 /* `hidden` has to be spelled out because a class selector outranks the UA's
-   [hidden] rule - without this an empty grid stayed on the page and its bottom
-   margin with it, opening a gap above the browse link on exactly the runs
-   where nothing had loaded. */
+   [hidden] rule */
 .template-mosaic[hidden] {
   display: none;
 }
@@ -411,10 +401,6 @@ h1,
   backface-visibility: hidden;
 }
 
-/* Twelve light screenshots on a black page shout. Holding the wall back and
-   bringing a single tile forward on hover makes this read as a catalog being
-   browsed rather than as twelve things competing, and it is the one deliberate
-   effect in the section - everything else here stays still. */
 .template-tile {
   display: flex;
   flex-direction: column;
@@ -2493,9 +2479,6 @@ input:checked + .slider::before {
   color: var(--color-secondary-interactive);
 }
 
-/* Separates the prompt frame from the Claude Code button. On its own line so
-   the two calls to action read as alternatives rather than a sequence. */
-/* The lead-in sits above the CTA as its own quiet line. */
 .build-alt {
   margin: 2rem 0 1rem;
   font-size: var(--typo-body-size);

--- a/style/main.css
+++ b/style/main.css
@@ -271,7 +271,6 @@ h1,
    tiles arrive and leave rather than appearing and vanishing at a hard edge. */
 .marquee-row {
   perspective: 900px;
-  perspective-origin: 50% 50%;
   overflow: hidden;
   /* Room for what draws outside a tile: the frame's ring, the hover scale, and
      the curve, which grows the tiles out at the sides by about a quarter.
@@ -306,6 +305,31 @@ h1,
 
 .marquee-track.reverse {
   animation-direction: reverse;
+}
+
+/* Each band's vanishing point sits on the edge it shares with the other one,
+   so a tile coming toward the camera grows AWAY from its neighbour rather than
+   into it. Centred origins made both bands swell toward the middle, closing
+   the gap between them from 103px to 33px out at the sides - they read as
+   bending into each other. Now the pair opens out.
+
+   Which is also why the padding below is lopsided: the growth all goes to the
+   outer edge, so that is the only side that needs room for it. Measured, not
+   guessed - the top band was overflowing its row by 16px above and nothing
+   below, and the bottom band by 19px below and nothing above. A wide viewport
+   puts more tiles at full extension, so this is set from the worst case out at
+   3000px rather than the first width it happened to look right at.
+
+   It is sized for --curve-depth above: raise the depth and this has to follow,
+   or the tops come off again. */
+.marquee-row:first-child {
+  perspective-origin: 50% 100%;
+  padding-top: 4.15rem;
+}
+
+.marquee-row:last-child {
+  perspective-origin: 50% 0%;
+  padding-bottom: 4.15rem;
 }
 
 /* Pausing on hover is not decoration here: every tile is a link, and reaching

--- a/style/main.css
+++ b/style/main.css
@@ -203,7 +203,10 @@ h1,
   font-weight: 700;
   line-height: 1.1;
   color: var(--color-typography-primary);
-  margin: 0 0 3rem;
+  /* No bottom margin: the space under this line is set by .template-mosaic's
+     own top margin, which has to cancel the rows' padding first. Two margins
+     would collapse against each other and the result would not be either. */
+  margin: 0;
   font-feature-settings: "ss01" on;
 }
 
@@ -242,14 +245,16 @@ h1,
 .template-mosaic {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0;
   width: 100vw;
   max-width: 100vw;
   margin-left: 50%;
   transform: translateX(-50%);
-  /* Closer to the link below than to the heading above: the link is the rows'
-     overflow, so the two belong to each other. */
-  margin-bottom: 2rem;
+  /* Both cancel the outer padding, so what is left is the gap you actually
+     see: 4rem above, matching the space over the heading, and 3rem below,
+     which keeps the link tied to the band whose overflow it names. */
+  margin-top: calc(4rem - var(--band-pad-outer));
+  margin-bottom: calc(3rem - var(--band-pad-outer));
   text-align: left;
 }
 
@@ -274,6 +279,19 @@ h1,
 .template-mosaic {
   --curve-depth: 0.132;
   --curve-turn: 34deg;
+
+  /* The rows carry padding so the curve has somewhere to grow into. That is
+     scaffolding, not spacing - left to set the gaps it made them a function of
+     the curve, so the space under the heading ran from 82px to 153px across
+     the widths while the space above it stayed at 64px.
+
+     The outer padding is cancelled by the margins below, so the gaps around
+     the bands are stated here and hold at every width. The inner padding is
+     the gap between the two bands, and it is proportional: fixed, it was 76px
+     whether the tiles were 149px wide or 431px, which read as a chasm on a
+     small window and a seam on a large one. */
+  --band-pad-outer: clamp(2.5rem, 5vw, 7rem);
+  --band-pad-inner: clamp(0.9rem, 1.3vw, 1.9rem);
 }
 
 /* The mask is what keeps this from reading as content that has been cut off:
@@ -286,7 +304,7 @@ h1,
   /* Room for what draws outside a tile: the frame's ring, the hover scale, and
      the curve, which grows the tiles out at the sides by about a quarter.
      Without it overflow:hidden clipped the top edge of every thumbnail. */
-  padding: 1.9rem 0;
+  padding: var(--band-pad-inner) 0;
   /* The names grow with the tiles, or a 14px label under a 428px thumbnail
      reads as a caption that got left behind. */
   font-size: clamp(0.875rem, 1vw, 1.15rem);
@@ -338,12 +356,12 @@ h1,
    or the tops come off again. */
 .marquee-row:first-child {
   perspective-origin: 50% 100%;
-  padding-top: clamp(2.5rem, 5vw, 7rem);
+  padding-top: var(--band-pad-outer);
 }
 
 .marquee-row:last-child {
   perspective-origin: 50% 0%;
-  padding-bottom: clamp(2.5rem, 5vw, 7rem);
+  padding-bottom: var(--band-pad-outer);
 }
 
 /* Pausing on hover is not decoration here: every tile is a link, and reaching

--- a/style/main.css
+++ b/style/main.css
@@ -260,22 +260,36 @@ h1,
    to be driven per frame rather than declared here - a tile's place in the row
    is what decides its transform, and that changes constantly.
 
-   --curve-depth is how far the ends come forward, --curve-turn how far they
-   turn to face you. Both are read by the script; tune them here. */
+   --curve-depth is how far the ends come forward, as a FRACTION of the row's
+   width rather than a length, and --curve-turn how far they turn to face you.
+   Both are read by the script; tune them here.
+
+   A fraction because everything here scales with the display: the tiles, the
+   camera distance below, and this. Held at fixed pixels while the row grew,
+   the same camera covered an ever wider field - a 35deg half-angle at 1280px
+   became 62deg at 3400px, and tiles out at the edges stretched half again as
+   wide as they were tall. Proportions keep the geometry identical at every
+   size, so a bigger display gets a bigger version of the same picture rather
+   than a more distorted one. */
 .template-mosaic {
-  --curve-depth: 190px;
+  --curve-depth: 0.132;
   --curve-turn: 34deg;
 }
 
 /* The mask is what keeps this from reading as content that has been cut off:
    tiles arrive and leave rather than appearing and vanishing at a hard edge. */
 .marquee-row {
-  perspective: 900px;
+  /* Proportional, so the field of view is the same at every width: the row is
+     100vw, and this is 0.625 of it - the 900px that looked right at 1440. */
+  perspective: 62.5vw;
   overflow: hidden;
   /* Room for what draws outside a tile: the frame's ring, the hover scale, and
      the curve, which grows the tiles out at the sides by about a quarter.
      Without it overflow:hidden clipped the top edge of every thumbnail. */
   padding: 1.9rem 0;
+  /* The names grow with the tiles, or a 14px label under a 428px thumbnail
+     reads as a caption that got left behind. */
+  font-size: clamp(0.875rem, 1vw, 1.15rem);
   -webkit-mask-image: linear-gradient(
     90deg,
     transparent,
@@ -324,12 +338,12 @@ h1,
    or the tops come off again. */
 .marquee-row:first-child {
   perspective-origin: 50% 100%;
-  padding-top: 4.15rem;
+  padding-top: clamp(2.5rem, 5vw, 7rem);
 }
 
 .marquee-row:last-child {
   perspective-origin: 50% 0%;
-  padding-bottom: 4.15rem;
+  padding-bottom: clamp(2.5rem, 5vw, 7rem);
 }
 
 /* Pausing on hover is not decoration here: every tile is a link, and reaching
@@ -368,7 +382,10 @@ h1,
 }
 
 .template-tile {
-  flex: 0 0 15rem;
+  /* Grows with the display. The floor is the size this was designed at, so
+     nothing at or below 1440px changes; above it the tiles get bigger rather
+     than the row merely fitting more of them. */
+  flex: 0 0 clamp(15rem, 16.7vw, 28rem);
   margin-right: 1rem;
   /* Set per frame by the curve; the tile's own box never moves, only the face
      it presents. */
@@ -456,7 +473,7 @@ h1,
 }
 
 .template-tile-name {
-  font-size: 0.875rem;
+  font-size: inherit;
   font-weight: 600;
   line-height: 1.3;
   color: var(--color-typography-secondary);

--- a/style/main.css
+++ b/style/main.css
@@ -201,7 +201,7 @@ h1,
   font-weight: 700;
   line-height: 1.1;
   color: var(--color-typography-primary);
-  margin: 0 0 2rem;
+  margin: 0 0 3rem;
   font-feature-settings: "ss01" on;
 }
 
@@ -213,10 +213,6 @@ h1,
   line-height: 1.6;
 }
 
-.build-description-break {
-  display: inline;
-}
-
 /* --- template mosaic ------------------------------------------------------
    A fixed window onto the catalog: twelve tiles however many templates exist,
    so the section's height is a constant rather than a function of the catalog.
@@ -225,38 +221,21 @@ h1,
    makes. Names are set quiet so the eye lands on the sites, not on a wall of
    labels. */
 
-/* The heading and the grid are shown together, so they share a wrapper: a
-   "Featured templates" label standing over nothing would be worse than no
-   label. `hidden` has to be spelled out because a class selector outranks the
-   UA's [hidden] rule - without this the empty wrapper stayed on the page and
-   its bottom margin with it, opening a gap above the browse link on exactly
-   the runs where nothing had loaded. */
-.featured-templates[hidden] {
+/* `hidden` has to be spelled out because a class selector outranks the UA's
+   [hidden] rule - without this an empty grid stayed on the page and its bottom
+   margin with it, opening a gap above the browse link on exactly the runs
+   where nothing had loaded. */
+.template-mosaic[hidden] {
   display: none;
-}
-
-.featured-templates {
-  margin: 0 0 3rem;
-}
-
-/* A label for the grid, not a second hero. The Build face and 1.5rem are what
-   a subordinate heading is set in elsewhere on the site; this sits just under
-   that, far enough below the 3rem above it to read as belonging to the grid
-   rather than competing for the section. */
-.featured-heading {
-  font-family: "Build", system-ui, sans-serif;
-  font-size: 1.25rem;
-  font-weight: 700;
-  line-height: 1.1;
-  color: var(--color-typography-primary);
-  font-feature-settings: "ss01" on;
-  margin: 0 0 1.25rem;
 }
 
 .template-mosaic {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1.25rem 1rem;
+  /* Closer to the link below than to the heading above: the link is the grid's
+     overflow, so the two belong to each other. */
+  margin: 0 0 2rem;
   text-align: left;
 }
 
@@ -361,6 +340,22 @@ h1,
 
 .browse-templates:hover .browse-templates-arrow {
   transform: translateX(3px);
+}
+
+/* Fades out at both ends rather than ruling a line across the column: it
+   separates two ways forward from each other without cutting the section in
+   half. */
+.build-divider {
+  height: 1px;
+  width: min(16rem, 55%);
+  margin: 3rem auto 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--color-transparent-border) 30%,
+    var(--color-transparent-border) 70%,
+    transparent
+  );
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1807,10 +1802,6 @@ h1.pricing-title {
   .hero-message {
     font-size: clamp(2rem, 11vw, 7.5rem);
     padding: 0 1rem;
-  }
-
-  .build-description-break {
-    display: none;
   }
 
   .demo-video {

--- a/style/main.css
+++ b/style/main.css
@@ -217,10 +217,132 @@ h1,
   display: inline;
 }
 
-#generate-frame {
-  border: 0;
+/* --- template mosaic ------------------------------------------------------
+   A fixed window onto the catalog: twelve tiles however many templates exist,
+   so the section's height is a constant rather than a function of the catalog.
+
+   The screenshots are the content here, the same bet the editor's own gallery
+   makes. Names are set quiet so the eye lands on the sites, not on a wall of
+   labels. */
+
+.template-mosaic {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.25rem 1rem;
+  margin: 0 0 3rem;
+  text-align: left;
+}
+
+/* Twelve light screenshots on a black page shout. Holding the wall back and
+   bringing a single tile forward on hover makes this read as a catalogue being
+   browsed rather than as twelve things competing, and it is the one deliberate
+   effect in the section - everything else here stays still. */
+.template-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  text-decoration: none;
+  opacity: 0.72;
+  transition: opacity 200ms ease;
+}
+
+.template-tile:hover,
+.template-tile:focus-visible {
+  opacity: 1;
+}
+
+.template-tile-shot {
+  display: block;
+  position: relative;
+  /* The editor captures thumbnails at 1280x960, so the box is 4:3 and the
+     image never has to be letterboxed or cropped to fit it. */
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 0.375rem;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 0 0 1px var(--color-transparent-border);
+  transition: box-shadow 200ms ease;
+}
+
+/* The site's own framing idiom, borrowed rather than invented: the same double
+   ring --style-double-border draws elsewhere, tightened to this scale. */
+.template-tile:hover .template-tile-shot,
+.template-tile:focus-visible .template-tile-shot {
+  box-shadow:
+    0 0 0 2px var(--color-main-bg),
+    0 0 0 4px var(--color-transparent-border);
+}
+
+.template-tile:focus-visible {
+  outline: none;
+}
+
+.template-tile:focus-visible .template-tile-shot {
+  box-shadow:
+    0 0 0 2px var(--color-main-bg),
+    0 0 0 4px var(--color-secondary-interactive);
+}
+
+.template-tile-shot img {
+  display: block;
   width: 100%;
-  min-height: 21rem;
+  height: 100%;
+  object-fit: cover;
+  object-position: top center;
+}
+
+/* Thumbnails only exist once the gallery ships, and a template whose shot has
+   not been captured should still be pickable. The frame stays, the broken
+   image goes. */
+.template-tile.no-shot .template-tile-shot img {
+  display: none;
+}
+
+.template-tile-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-typography-secondary);
+  transition: color 200ms ease;
+}
+
+.template-tile:hover .template-tile-name,
+.template-tile:focus-visible .template-tile-name {
+  color: var(--color-typography-primary);
+}
+
+.browse-templates {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-primary-cta-highlight);
+  font-size: 1.0625rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.browse-templates:hover,
+.browse-templates:focus-visible {
+  color: var(--color-primary-cta-shadow);
+}
+
+/* The arrow moves, the words do not: the whole control sliding would read as
+   the page shifting rather than as a direction. */
+.browse-templates-arrow {
+  transition: transform 200ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.browse-templates:hover .browse-templates-arrow {
+  transform: translateX(3px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .template-tile,
+  .template-tile-shot,
+  .template-tile-name,
+  .browse-templates-arrow {
+    transition: none;
+  }
 }
 
 .pricing-page {
@@ -1707,8 +1829,16 @@ h1.pricing-title {
     padding: 8rem 2rem 2rem;
   }
 
-  #generate-frame {
-    min-height: 28rem;
+  /* Fewer, larger tiles rather than the same twelve shrunk: below this a
+     screenshot stops being legible enough to choose from, and six good ones
+     beat twelve unreadable ones. The count in the link still says how many
+     there really are. */
+  .template-mosaic {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .template-tile:nth-child(n + 10) {
+    display: none;
   }
 
   .benefit-grid:not(.benefit-grid--compact),
@@ -2234,4 +2364,18 @@ input:checked + .slider::before {
 .link-fineprint {
   margin-top: 2rem;
   max-width: 52ch;
+}
+
+/* Phones. Placed here rather than beside the other mosaic rules because the
+   3-column override lives in the 768px block further up: an earlier rule at
+   equal specificity would lose to it at every width this one cares about. */
+@media (max-width: 520px) {
+  .template-mosaic {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem 0.75rem;
+  }
+
+  .template-tile:nth-child(n + 7) {
+    display: none;
+  }
 }

--- a/style/main.css
+++ b/style/main.css
@@ -225,19 +225,38 @@ h1,
    makes. Names are set quiet so the eye lands on the sites, not on a wall of
    labels. */
 
-/* The grid is filled in by JS, and `hidden` has to be spelled out here: a
-   class selector outranks the UA's [hidden] rule, so `display: grid` alone
-   would leave an empty grid on the page - and its bottom margin with it,
-   opening a gap above the browse link whenever the catalog cannot load. */
-.template-mosaic[hidden] {
+/* The heading and the grid are shown together, so they share a wrapper: a
+   "Featured templates" label standing over nothing would be worse than no
+   label. `hidden` has to be spelled out because a class selector outranks the
+   UA's [hidden] rule - without this the empty wrapper stayed on the page and
+   its bottom margin with it, opening a gap above the browse link on exactly
+   the runs where nothing had loaded. */
+.featured-templates[hidden] {
   display: none;
+}
+
+.featured-templates {
+  margin: 0 0 3rem;
+}
+
+/* A label for the grid, not a second hero. The Build face and 1.5rem are what
+   a subordinate heading is set in elsewhere on the site; this sits just under
+   that, far enough below the 3rem above it to read as belonging to the grid
+   rather than competing for the section. */
+.featured-heading {
+  font-family: "Build", system-ui, sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--color-typography-primary);
+  font-feature-settings: "ss01" on;
+  margin: 0 0 1.25rem;
 }
 
 .template-mosaic {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1.25rem 1rem;
-  margin: 0 0 3rem;
   text-align: left;
 }
 

--- a/style/main.css
+++ b/style/main.css
@@ -225,6 +225,14 @@ h1,
    makes. Names are set quiet so the eye lands on the sites, not on a wall of
    labels. */
 
+/* The grid is filled in by JS, and `hidden` has to be spelled out here: a
+   class selector outranks the UA's [hidden] rule, so `display: grid` alone
+   would leave an empty grid on the page - and its bottom margin with it,
+   opening a gap above the browse link whenever the catalog cannot load. */
+.template-mosaic[hidden] {
+  display: none;
+}
+
 .template-mosaic {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -234,7 +242,7 @@ h1,
 }
 
 /* Twelve light screenshots on a black page shout. Holding the wall back and
-   bringing a single tile forward on hover makes this read as a catalogue being
+   bringing a single tile forward on hover makes this read as a catalog being
    browsed rather than as twelve things competing, and it is the one deliberate
    effect in the section - everything else here stays still. */
 .template-tile {

--- a/style/product.css
+++ b/style/product.css
@@ -24,12 +24,12 @@
   --m-editor-4-y: 20.9%;
 
   /* Prompt — "Describe what you want: Get real websites." */
-  --m-prompt-1-x: 94.7%;
-  --m-prompt-1-y: 21.7%;
-  --m-prompt-2-x: 53.6%;
-  --m-prompt-2-y: 39.2%;
-  --m-prompt-3-x: 50%;
-  --m-prompt-3-y: 57%;
+  --m-prompt-1-x: 97%;
+  --m-prompt-1-y: 21%;
+  --m-prompt-2-x: 97%;
+  --m-prompt-2-y: 56%;
+  --m-prompt-3-x: 64%;
+  --m-prompt-3-y: 88.5%;
 
   /* Settings — "Your site, your settings." (1 GitHub, 2 deploys, 3 DNS) */
   --m-settings-1-x: 42%;
@@ -831,46 +831,33 @@
   white-space: nowrap;
 }
 
-.pf-chooser {
+/* The gallery, as a strip. Six is enough to read as "there are more of these"
+   without becoming a grid, which would take the height the screen below it
+   needs. One is ringed, because the step this illustrates is the picking. */
+.pf-tile-strip {
   display: grid;
-  grid-template-columns: auto repeat(3, minmax(0, 1fr)) auto;
-  align-items: center;
-  gap: 0.6rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.5rem;
 }
-.pf-paddle {
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 999px;
-  background: var(--pf-glass);
-  border: 1px solid var(--pf-hairline);
-  color: var(--pf-text-dim);
-  display: grid;
-  place-items: center;
-  font-size: 1rem;
-  line-height: 1;
-}
-.pf-site-card {
+.pf-tile {
+  aspect-ratio: 4 / 3;
+  border-radius: 0.35rem;
   background: var(--pf-panel-2);
   border: 1px solid var(--pf-hairline);
-  border-radius: 0.5rem;
-  padding: 0.5rem;
+  padding: 0.3rem;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  opacity: 0.65;
-  transform: scale(0.94);
+  gap: 0.25rem;
+  opacity: 0.55;
   min-width: 0;
 }
-.pf-site-card--active {
+.pf-tile--active {
   opacity: 1;
-  transform: scale(1);
   border-color: var(--pf-violet);
-  box-shadow:
-    0 0 0 1px rgba(139, 92, 246, 0.4),
-    0 8px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 0 1px rgba(139, 92, 246, 0.4);
 }
-.pf-site-header {
-  height: 0.5rem;
+.pf-tile-header {
+  height: 0.25rem;
   border-radius: 999px;
   background: linear-gradient(
     90deg,
@@ -878,30 +865,51 @@
     rgba(0, 200, 255, 0.4)
   );
 }
-.pf-site-block {
-  height: 1.3rem;
-  border-radius: 0.25rem;
-  background: rgba(255, 255, 255, 0.08);
-}
-.pf-site-block--wide {
-  height: 2rem;
-}
-.pf-golive-btn {
-  margin-top: 0.25rem;
-  height: 1.75rem;
-  font-size: 0.68rem;
-  padding: 0 0.75rem;
+.pf-tile-body {
+  flex: 1;
+  border-radius: 0.2rem;
+  background: rgba(255, 255, 255, 0.07);
 }
 
+/* The title sits tight to the strip it names, so the two are one group rather
+   than two things a frame-wide gap has separated. */
+.pf-choose {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.pf-frame-title {
+  margin: 0;
+  text-align: center;
+  font-family: "Build", system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 1.05rem;
+  line-height: 1.1;
+  color: var(--pf-text);
+  font-feature-settings: "ss01" on;
+}
+.pf-optional-label {
+  align-self: center;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.6rem;
+  color: var(--pf-text-dim);
+  opacity: 0.75;
+}
+.pf-generate-btn {
+  align-self: center;
+}
 @media (max-width: 768px) {
   .product-frame--prompt {
     padding: 1rem;
     gap: 1.25rem;
   }
-  .pf-chooser {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  /* Four tiles rather than six: below this they stop reading as sites and
+     start reading as texture. */
+  .pf-tile-strip {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
-  .pf-paddle {
+  .pf-tile:nth-child(n + 5) {
     display: none;
   }
 }


### PR DESCRIPTION
The home page still sold the old onboarding: an embedded iframe that asked you
to describe a site, and a product-tour panel showing Archival picking a
template for you. Neither of those happens any more. This replaces both with
the flow that does.

## What changed

**The hero section.** The iframe is gone. In its place, two full-bleed bands of
real template screenshots drifting in opposite directions, each tile linking
straight to that template rather than to the grid — someone who has already
chosen should not have to choose again. Hovering pauses the band it is in,
because every tile is a link and reaching for a moving one is a fight.

The bands are treated as a screen bent around the viewer: flat straight ahead,
curling toward you at the ends, so tiles out at the sides sit nearer the camera
and draw larger. The treatment is lifted from the `professional` template's
testimonial marquee, with one fix — that version animates a 200%-wide track
holding one copy of its items, so the loop passes through empty space. Here each
track carries its templates enough times to cover the row, which makes -50%
exactly one pass and leaves no seam.

**The lead-in collapsed to one line.** It was a heading, a two-line description
and a "Featured templates" label stacked in front of twelve screenshots that say
it themselves. "Build yours right now." picks up *yours* from "websites for
everyone" directly above, so the two read as one thought.

**"Get started in minutes" redrawn.** It described the deleted flow in both its
copy and its illustration. It now shows what happens: pick a template,
optionally describe it, generate. Built from the same `.pf-*` primitives the
other frames use — the optional box *is* `.pf-prompt-card`, unchanged, which is
the point: describing your site did not go away, it stopped being the entrance.

## Two things worth knowing

**This needs the editor deploy first.** The tiles link to `/new?template=<id>`,
which is unmerged in archival-editor#332, and the thumbnails 404 until it ships.
Landing this first leaves twelve named-but-empty frames and links that fall back
to the grid.

**`/new` is not a page on this site.** Unmatched paths fall back to index.html
with a 200, so a relative link there quietly served the home page again rather
than 404ing. The browse link is absolute now, matching the nav's own Create
links, and `src/index.ts` repoints it at whichever editor the build targets.

## Degrading

Everything that matters is in the markup: heading, copy and browse link work
with no JS and no network, so a failed fetch leaves a section that still reads
and still leads somewhere. A template whose screenshot has not been captured
falls back to its name on an empty frame. Under `prefers-reduced-motion` the
drift and the curve both stop and the rows become scrollable.

## Verified

Widths 420 / 520 / 760 / 1280 / 1440 / 1800 / 2560 / 3400: the track covers the
row, the bands open outward rather than converging, nothing is clipped, and
there is no page-level horizontal scroll. The curve's half-angle is a constant
39° across that range. Median frame interval 8.5ms against a 16.7ms budget, and
the loop stops when the rows leave the viewport.

https://claude.ai/code/session_01XieitXQf7Dtx9D36KgBzce