### PR TITLE
Fix the browse link's hit area, and hold the mosaic's height

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -138,6 +138,19 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700;800;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/style/main.css">
+    {% comment %}
+      The template mosaic holds its height from the first paint so the CTA
+      under it never renders in its place, which means the empty band is in
+      the markup before the tiles that fill it exist. Without script those
+      tiles never arrive, so this takes the space back.
+    {% endcomment %}
+    <noscript>
+      <style>
+        .template-mosaic {
+          display: none;
+        }
+      </style>
+    </noscript>
     <script type="module" src="/scripts/main.js"></script>
   </head>
 

--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -84,7 +84,14 @@
 <div class="build-section">
   <h2 class="build-heading">Build yours right now.</h2>
 
-  <div id="template-mosaic" class="template-mosaic" hidden></div>
+  {% comment %}
+    Not hidden: the mosaic reserves its height here, in the markup, so the
+    link and the CTA below it are never painted in the band's place and then
+    pushed down when the catalog lands. src/index.ts hides it if the catalog
+    cannot be had, and the noscript rule in the layout hides it where nothing
+    will ever fill it.
+  {% endcomment %}
+  <div id="template-mosaic" class="template-mosaic"></div>
 
   <a
     id="browse-templates"

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,21 +95,21 @@ const pointBrowseLinkAtEditor = () => {
   }
 };
 
-const setupTemplateMosaic = async () => {
-  // Only the home page carries the mosaic. Bail before fetching anything so
-  // every other page does not pay for a request it will not use.
-  const mosaic = document.getElementById("template-mosaic");
-  if (!mosaic) {
-    return;
-  }
-
-  let templates: Template[];
+/**
+ * The editor's catalog, or null if it cannot be had.
+ *
+ * Separate from the mosaic itself because the mosaic has to hand its space
+ * back on every way this can fail, and one caller checking one value is
+ * harder to leave a hole in than four early returns.
+ */
+const loadTemplates = async (): Promise<Template[] | null> => {
   try {
     const response = await fetch(`${EDITOR_URL}/templates.json`);
     if (!response.ok) {
-      return;
+      return null;
     }
-    ({ templates } = (await response.json()) as { templates: Template[] });
+    const { templates } = (await response.json()) as { templates: Template[] };
+    return Array.isArray(templates) && templates.length > 0 ? templates : null;
   } catch (error) {
     // Degrading quietly is right for an unreachable editor: the section still
     // reads and the browse link still works. Saying so is right for everything
@@ -118,9 +118,24 @@ const setupTemplateMosaic = async () => {
     // captures its defines at startup and never re-reads build.mjs) and the
     // silence was the expensive part, not the failure.
     console.warn("Could not load the template catalog:", error);
+    return null;
+  }
+};
+
+const setupTemplateMosaic = async () => {
+  // Only the home page carries the mosaic. Bail before fetching anything so
+  // every other page does not pay for a request it will not use.
+  const mosaic = document.getElementById("template-mosaic");
+  if (!mosaic) {
     return;
   }
-  if (!Array.isArray(templates) || templates.length === 0) {
+
+  const templates = await loadTemplates();
+  if (!templates) {
+    // The band is in the markup and holding its height (so nothing below it
+    // moves when the tiles land), so an editor that cannot be reached has to
+    // give that space back rather than leave a band of nothing above the link.
+    mosaic.hidden = true;
     return;
   }
 
@@ -211,7 +226,6 @@ const setupTemplateMosaic = async () => {
     row(featured.slice(split), true),
   ];
   mosaic.append(...rows.map((r) => r.rowEl));
-  mosaic.hidden = false;
   // Measured, so it has to happen after the rows are laid out - and again when
   // the window grows, or a track that covered the row stops covering it.
   const refillAll = () => rows.forEach((r) => r.refill());

--- a/style/main.css
+++ b/style/main.css
@@ -283,6 +283,31 @@ h1,
   --band-pad-outer: clamp(2.5rem, 5vw, 7rem);
   --band-pad-inner: clamp(0.9rem, 1.3vw, 1.9rem);
 
+  /* A tile's size lives here rather than on .template-tile because the height
+     reserved below is computed from it. One set of numbers, so the space the
+     mosaic asks for while it is still empty is the space its tiles end up
+     taking. The breakpoints further down override --tile-w, not the tile. */
+  --tile-w: clamp(15rem, 16.7vw, 28rem);
+  --tile-name: clamp(0.875rem, 1vw, 1.15rem);
+  --tile-gap: 0.625rem;
+
+  /* Hold the bands' height from the first paint. The catalog comes over the
+     network, so without this the CTA below rendered up under the heading and
+     was thrown the height of the mosaic down the page when the tiles landed -
+     a flash of the wrong layout, and up to 0.15 of layout shift.
+
+     Both rows measure the same: their two paddings, a 4:3 thumbnail, the gap
+     under it and one line of name. src/index.ts collapses this again if the
+     catalog never arrives, so a dead editor costs an empty band for as long
+     as the request takes and nothing after that. */
+  min-height: calc(
+    2 *
+      (
+        var(--band-pad-outer) + var(--band-pad-inner) + var(--tile-w) * 0.75 +
+          var(--tile-gap) + 1.3 * var(--tile-name)
+      )
+  );
+
   /* That padding is scaffolding for the curve, not part of the band, and the
      negative margin above deliberately pulls the link below into it. Left
      interactive, the empty space swallowed every click meant for "Browse all
@@ -307,7 +332,7 @@ h1,
   padding: var(--band-pad-inner) 0;
   /* The names grow with the tiles, or a 14px label under a 428px thumbnail
      reads as a caption that got left behind. */
-  font-size: clamp(0.875rem, 1vw, 1.15rem);
+  font-size: var(--tile-name);
   -webkit-mask-image: linear-gradient(
     90deg,
     transparent,
@@ -407,7 +432,13 @@ h1,
   /* Grows with the display. The floor is the size this was designed at, so
      nothing at or below 1440px changes; above it the tiles get bigger rather
      than the row merely fitting more of them. */
-  flex: 0 0 clamp(15rem, 16.7vw, 28rem);
+  flex: 0 0 var(--tile-w);
+  /* A flex item will not shrink below its content, and the name above is one
+     unbroken line, so "Professional Template" made its tile 149px wide where
+     every other tile was 144 - and the 4:3 thumbnail turned those 5px into 4
+     more of height, which the whole row then took. The tile is exactly the
+     width it is told to be, and the name ellipsizes inside it. */
+  min-width: 0;
   margin-right: 1rem;
   /* Set per frame by the curve; the tile's own box never moves, only the face
      it presents. */
@@ -418,7 +449,7 @@ h1,
 .template-tile {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: var(--tile-gap);
   text-decoration: none;
   opacity: 0.72;
   transition: opacity 200ms ease;
@@ -496,6 +527,15 @@ h1,
   line-height: 1.3;
   color: var(--color-typography-secondary);
   transition: color 200ms ease;
+  /* One line, always. A name that wrapped made its tile taller, its row
+     taller than the height the mosaic reserves, and - since the catalog is
+     shuffled - the two rows different heights on some loads and not others.
+     "Professional Template" wrapped at 9rem tiles, so this is the phone
+     widths in practice. Truncating is the smaller loss: the tile is a link to
+     the gallery, where the name is written out in full. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .template-tile:hover .template-tile-name,
@@ -2040,9 +2080,10 @@ h1.pricing-title {
   }
 
   /* Smaller tiles rather than fewer: the row carries as many as it carries,
-     and every template still goes past. */
-  .template-tile {
-    flex-basis: 11rem;
+     and every template still goes past. Set on the mosaic because the height
+     it reserves is computed from this. */
+  .template-mosaic {
+    --tile-w: 11rem;
   }
 
   .benefit-grid:not(.benefit-grid--compact),
@@ -2571,8 +2612,8 @@ input:checked + .slider::before {
    override at 768px lives further up the file: an earlier rule at equal
    specificity would lose to it at every width this one cares about. */
 @media (max-width: 520px) {
-  .template-tile {
-    flex-basis: 9rem;
+  .template-mosaic {
+    --tile-w: 9rem;
   }
 
   .marquee-row {

--- a/style/main.css
+++ b/style/main.css
@@ -282,6 +282,16 @@ h1,
      small window and a seam on a large one. */
   --band-pad-outer: clamp(2.5rem, 5vw, 7rem);
   --band-pad-inner: clamp(0.9rem, 1.3vw, 1.9rem);
+
+  /* That padding is scaffolding for the curve, not part of the band, and the
+     negative margin above deliberately pulls the link below into it. Left
+     interactive, the empty space swallowed every click meant for "Browse all
+     templates" and paused the drift whenever the pointer came near it - the
+     bands sit in a stacking context of their own (the translate), so they
+     take the hit even though the link comes after them. Only the track opts
+     back in, and hover-to-pause is unaffected: a pointer over a tile still
+     puts :hover on the row above it. */
+  pointer-events: none;
 }
 
 /* The mask is what keeps this from reading as content that has been cut off:
@@ -321,6 +331,7 @@ h1,
 .marquee-track {
   display: flex;
   width: max-content;
+  pointer-events: auto;
   transform-style: preserve-3d;
   /* The duration is overwritten by src/index.ts once the track is filled: the
      keyframe moves a percentage of the track, so holding one duration would


### PR DESCRIPTION
Two things the gallery flow got wrong on the marketing page.

## "Browse all templates ->" could not be clicked, and hovering it stopped the drift

One cause, not two. The bands carry `padding: var(--band-pad-outer)` as scaffolding for the curve, and `.template-mosaic`'s `margin-bottom: calc(3rem - var(--band-pad-outer))` goes negative at wide viewports (-32px at 1600px), which deliberately pulls the link up into that empty padding. The mosaic is `transform: translateX(-50%)`, so it sits in a stacking context of its own and took the hit even though the link comes after it in the DOM. Playwright named it outright: `<div class="marquee-row"> ... intercepts pointer events`, and a click at the link's center landed on `marquee-row`. Same reason the drift paused: the pointer was inside the row, so `.marquee-row:hover` fired.

The scaffolding no longer takes hits, and only `.marquee-track` opts back in. Hover-to-pause is unchanged, since a pointer over a tile still puts `:hover` on the row above it.

## A flash of "Build it with Claude" before the tracks arrived

The mosaic shipped `hidden` and unhid only when `templates.json` came back, so the CTA painted up under the heading and was thrown the height of the mosaic down the page. Measured 0.09 to 0.15 of layout shift. Unhiding earlier from script only moved the shift earlier (the page paints before a module script runs), so the space is taken in the markup instead: a tile's size becomes tokens on the mosaic, and a `min-height` computed from those tokens holds the bands' height from the first paint. Where nothing will ever fill it, the band gives the space back: a `noscript` rule for a visitor without script, and `index.ts` for an editor that cannot be reached.

Two things follow from making that reservation honest:

- Names hold to one line and ellipsize. A wrapping name made its row taller than the height reserved for it and, the catalog being shuffled, made the two rows different heights on some loads and not others.
- Tiles take `min-width: 0`. With one unbroken line, "Professional Template" became its tile's automatic minimum width (149px against 144), which the 4:3 thumbnail turned into height the whole row then took.

## Verification

Headless Chromium, at 380, 480, 700, 900, 1280 and 1600:

- The link is clickable at every width, and hovering it leaves the drift running.
- Hovering the band still pauses it; so does focusing a tile with the keyboard (`:focus-within`).
- Reserved height and filled height agree to 0.00px at every width.
- CLS is 0.0004 to 0.0015, down from 0.09 to 0.15. What is left is the pre-existing font shift, which lands before the mosaic does.
- Catalog unreachable: the band collapses, no gap left above the link.
- No script at all: no gap.
- Reduced motion: the rows still scroll horizontally, and the link still clicks.

`scripts/check-meta.sh` passes and prettier is clean.

https://claude.ai/code/session_01FB7zF31T9M8dhM1jeAx1wp