### PR TITLE
Fix the mosaic in Safari, the wrapping nav, and the stacked tour's alignment

### DIFF
--- a/pages/_nav.liquid
+++ b/pages/_nav.liquid
@@ -43,7 +43,7 @@
       <div class="hidden md:flex">⌘K</div>
     </button>
   </div>
-  <ul class="flex-shrink justify-end gap-8 items-center flex-wrap hidden md:flex">
+  <ul class="flex-shrink justify-end gap-8 items-center flex-nowrap whitespace-nowrap hidden lg:flex">
     {% comment %}
       The tour lives on the homepage now, so this item has no page of its own to
       match on. index.liquid scroll-spies it instead: active while the tour is
@@ -83,7 +83,7 @@
       <a href="https://editor.archival.dev/new" data-umami-event="nav-create">Create</a>
     </li>
   </ul>
-  <div class="md:hidden flex items-center">
+  <div class="lg:hidden flex items-center">
     <button>
       <div id="menu-closed">
         <svg
@@ -145,7 +145,7 @@
 </nav>
 <div
   id="mobile-menu"
-  class="hidden fixed backdrop-blur-md translate-y-full transition opacity-0 shadow-up w-full pb-10 px-4 bottom-0 z-40 text-xl rounded-lg md:hidden max-h-full overflow-y-auto"
+  class="hidden fixed backdrop-blur-md translate-y-full transition opacity-0 shadow-up w-full pb-10 px-4 bottom-0 z-40 text-xl rounded-lg lg:hidden max-h-full overflow-y-auto"
 >
   <ul class="flex flex-col">
     <li class="mobile-nav-item">

--- a/style/main.css
+++ b/style/main.css
@@ -433,6 +433,16 @@ h1,
      nothing at or below 1440px changes; above it the tiles get bigger rather
      than the row merely fitting more of them. */
   flex: 0 0 var(--tile-w);
+  /* The same width again, as a definite one. The basis alone is enough in
+     Blink, but WebKit sizes the max-content track from each tile's intrinsic
+     content instead, and the widest thing in a tile is a 2560px thumbnail. The
+     track laid out at 12 x 2576px = 30912px rather than 12 x 160px = 1920px,
+     which is a band of mostly empty space whose -50% keyframe then travels
+     sixteen times as far in the same duration: on iPhone the tiles tore past
+     and the curve, fed a track box that wide, pinned every visible tile at the
+     clamp and blew it up until the second band was off screen. Chrome's device
+     mode is still Blink, so it never showed any of this. */
+  width: var(--tile-w);
   /* A flex item will not shrink below its content, and the name above is one
      unbroken line, so "Professional Template" made its tile 149px wide where
      every other tile was 144 - and the 4:3 thumbnail turned those 5px into 4
@@ -464,8 +474,10 @@ h1,
   display: block;
   position: relative;
   transform-origin: center;
-  /* The editor captures thumbnails at 1280x960, so the box is 4:3 and the
-     image never has to be letterboxed or cropped to fit it. */
+  /* The editor captures thumbnails at 2560x1920, so the box is 4:3 and the
+     image never has to be letterboxed or cropped to fit it. That 2560 is also
+     the tile's intrinsic width, which is why .template-tile has to state a
+     definite width above. */
   aspect-ratio: 4 / 3;
   overflow: hidden;
   border-radius: 0.375rem;

--- a/style/product.css
+++ b/style/product.css
@@ -2,6 +2,10 @@
 .product-page {
   width: 100%;
   overflow-x: clip;
+  /* The width every frame is laid out at before fit() scales it. Lives here,
+     not on .product-frame, because the stacked breakpoint sizes the column
+     from it as well, and the two have to be the same number to line up. */
+  --pf-dw: 33.5rem;
   /* #product is the nav's anchor target; clear the fixed nav on jump.
      Matches the offset used for docs headings in markdown.css. */
   scroll-margin-top: 100px;
@@ -178,6 +182,14 @@
     grid-template-columns: minmax(0, 1fr);
     gap: 2rem;
     margin: 5rem auto;
+    /* Stacked, the copy, the frame and the legend are one column, so the
+       column stops at the width the frame stops at. Without this the section
+       kept growing while the frame held at --pf-dw and margin-inline centered
+       it, so from 601px up the frame drifted right while the copy above and
+       the legend below stayed on the left edge. Capping here keeps all three
+       on one edge and centers the section instead, which is what every other
+       band on the site already does. */
+    max-width: calc(var(--pf-dw) + 4rem);
   }
   .product-section.frame-left {
     direction: ltr;
@@ -202,7 +214,6 @@
   --pf-violet: rgba(139, 92, 246, 1);
   --pf-teal: #7ec8b8;
   --pf-purple: #b87fd4;
-  --pf-dw: 33.5rem;
 
   position: relative;
   border-radius: 1rem;


### PR DESCRIPTION
Three responsive fixes, each in its own commit. Nothing changes on desktop Chrome, which is where all of this looked fine.

## The mosaic showed one row, tearing past, on iPhone

`.marquee-track` is `width: max-content`. Blink sizes it from each tile's `flex: 0 0 var(--tile-w)` basis. WebKit sizes it from the tile's intrinsic content instead, and the widest thing in a tile is the thumbnail, which is 2560px wide. So on a phone the track laid out at 12 x 2576px = **30912px** rather than 12 x 160px = **1920px**.

Both symptoms come from that one number:

- The keyframe travels `-50%` of the track, so the drift ran at **171.7 px/sec instead of 10.7**, exactly 16x too fast.
- `drawCurve` anchors on `track.getBoundingClientRect()`. Handed a box that wide, `p` saturates at +/-1 for every visible tile, so they all took the maximum `translateZ(51.5px) rotateY(34deg)`. Off-axis that projection blew tiles up to 552px and 7214px wide, which swamped the viewport and pushed the second band out of view.

The track is also mostly empty at that width, which is the other half of why it read as broken.

Stating the width as well as the basis makes the item's contribution definite in both engines. Isolated first in a standalone repro with no network, no animation and no 3D; of four candidates only the definite `width` worked (`max-width: 100%` and capping the img did nothing, `contain: size` broke layout).

**Worth knowing: desktop Safari was broken too.** WebKit at 1440px also laid out at 30912px. Desktop looking fine was Chrome, not Safari.

Also corrects the thumbnail dimensions in the comment above from 1280x960 to 2560x1920. That wrong premise is what made this invisible in review.

## The nav wrapped to two rows between 769px and 929px

The hamburger switched at `md` (768px), but the seven items need **929px** to sit on one line. Everything in that 160px band got the desktop nav, which then wrapped because the list carried `flex-wrap` (nav height 80px to 136px).

Moved to `lg` (976px), already in the scale, clearing 929 with room for a longer item later. Three classes had to move together, and the third is the one that would have bitten: `#mobile-menu` was also `md:hidden`, so changing only the button would have given the band a menu button with nothing behind it.

`flex-wrap` becomes `flex-nowrap whitespace-nowrap`. A nav bar that wraps is never the intent, so it is now impossible rather than merely unlikely.

## The tour's panels drifted off the left edge between 601px and 768px

Stacked, the copy, the frame and the callout legend are one reading column. But the frame holds at `--pf-dw` (536px) with `margin-inline: auto`, so once the column passed 536px the frame centered itself while the heading above and the legend below stayed on the left edge. At 737px the frame sat 69px right of everything else.

The column now stops where the frame stops, and the section centers as a block, which is what `.build-section` and `.product-section` already do. `--pf-dw` moves up to `.product-page` so the column and the frame read one number instead of two copies of it.

## Verification

Chrome DevTools device mode cannot catch the first of these, since it is still Blink. Tested against real WebKit (Playwright's, 26.5) as well as Chromium.

| | track width | drift | widest tile |
|---|---|---|---|
| Chromium iPhone 14 | 1920px | 10.7 px/s | 219px |
| WebKit iPhone 14, before | 30912px | 171.7 px/s | 7214px |
| WebKit iPhone 14, after | 1920px | 10.7 px/s | 295px |

- Swept 360px to 1600px in 10px steps: 0 nav wraps, 0 stacked-alignment failures, no horizontal scroll.
- Clicked the hamburger at 390, 800, 900 and 970px: menu opens with all seven items at each.
- Desktop at 1440px is identical to production before and after (`navH=80 copyL=152 frameL=752 frameW=536`), so nothing above the breakpoint moved.
- WebKit and Chromium now agree to within 1px at 390px and 1440px.

## Not addressed

The quick-search button in the nav is dead code: it carries both `flex` and `hidden` with no `md:flex` to override, so it computes to `display: none` at every width and its `md:*` classes never apply. Left alone as out of scope, but worth deleting or fixing.

https://claude.ai/code/session_013oNA6ETp6gzSGmmpyn3euT
